### PR TITLE
Problem: CI is failing for pulp-container's 1.0 branch

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -74,7 +74,7 @@ if [ -n "$PULP_OPERATOR_PR_NUMBER" ]; then
 fi
 
 
-git clone --depth=1 https://github.com/pulp/pulpcore.git
+git clone --depth=1 https://github.com/pulp/pulpcore.git --branch master
 
 if [ -n "$PULP_PR_NUMBER" ]; then
   cd pulpcore

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,4 +1,4 @@
 ecdsa~=0.13.2
 git+https://github.com/PulpQE/pulp-smash.git#egg=pulp-smash
 pyjwkest~=1.4.0
-pulpcore~=3.0rc7
+pulpcore>=3.0rc8,<3.2

--- a/template_config.yml
+++ b/template_config.yml
@@ -34,8 +34,11 @@ plugin_dash_short: container
 plugin_name: pulp_container
 plugin_snake: pulp_container
 pulp_settings:
+  private_key_path: /var/lib/pulp/tmp/private.pem
+  public_key_path: /var/lib/pulp/tmp/public.pem
   token_server: $(hostname):24816/token
   token_signature_algorithm: ES256
+pulpcore_branch: master
 pydocstyle: true
 pypi_username: pulp
 test: false


### PR DESCRIPTION
due to it needing pulp 3.0, but master is getting installed.

Solution: regenerate from plugin-template, and set pulpcore_branch:
master/master & 1.0/3.0


[noissue]

re: #5782
plugin-template needs to support both the pulpcore 3.0 and master branch for plugins
https://pulp.plan.io/issues/5782