### PR TITLE
Do not prepend a scheme to a token server in the Www-Authenticate header

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -93,7 +93,7 @@ spec:
   pulp_settings:
      private_key_path: /var/lib/pulp/tmp/private.pem
      public_key_path: /var/lib/pulp/tmp/public.pem
-     token_server: $(hostname):24816/token
+     token_server: http://$(hostname):24816/token
      token_signature_algorithm: ES256
     
 CRYAML

--- a/CHANGES/5779.bugfix
+++ b/CHANGES/5779.bugfix
@@ -1,0 +1,1 @@
+Allow users to provide fully qualified domain name of a token server with an associated port number

--- a/docs/workflows/authentication.rst
+++ b/docs/workflows/authentication.rst
@@ -9,8 +9,9 @@ user's privileges and current scope.
 
 The feature is enabled by default. However, it is required to define the following settings first:
 
-    - **A fully qualified domain name of a token server**. The token server is responsible for generating
-      Bearer tokens. Append the constant ``TOKEN_SERVER`` to the settings file ``pulp_container/app/settings.py``.
+    - **A fully qualified domain name of a token server with an associated port number**. The token server is
+      responsible for generating Bearer tokens. Append the constant ``TOKEN_SERVER`` to the settings file
+      ``pulp_container/app/settings.py``.
     - **A token signature algorithm**. A particular signature algorithm can be chosen only from the list of
       `supported algorithms <https://pyjwt.readthedocs.io/en/latest/algorithms.html#digital-signature-algorithms>`_.
       Pulp uses exclusively asymmetric cryptography to sign and validate tokens. Therefore, it is possible
@@ -33,7 +34,7 @@ Below is provided and example of the settings file:
 
 .. code-block:: python
 
-    TOKEN_SERVER = "localhost:24816/token"
+    TOKEN_SERVER = "http://localhost:24816/token"
     TOKEN_SIGNATURE_ALGORITHM = 'ES256'
     PUBLIC_KEY_PATH = '/tmp/public_key.pem'
     PRIVATE_KEY_PATH = '/tmp/private_key.pem'

--- a/pulp_container/app/authorization.py
+++ b/pulp_container/app/authorization.py
@@ -1,3 +1,4 @@
+import re
 import base64
 import hashlib
 import random
@@ -16,7 +17,7 @@ from pulpcore.plugin.content import Handler
 
 TOKEN_EXPIRATION_TIME = 300
 
-KNOWN_SERVICES = [settings.CONTENT_ORIGIN]
+KNOWN_SERVICES = [re.sub(r'(http://|https://)', '', settings.CONTENT_ORIGIN, count=1)]
 ANONYMOUS_USER = ''
 EMPTY_ACCESS_SCOPE = '::'
 

--- a/pulp_container/app/token_verification.py
+++ b/pulp_container/app/token_verification.py
@@ -1,7 +1,10 @@
+import re
 import jwt
 
 from aiohttp import web
 from django.conf import settings
+
+CONTENT_HOST = re.sub(r'(http://|https://)', '', settings.CONTENT_ORIGIN, count=1)
 
 
 class TokenVerifier:
@@ -94,11 +97,11 @@ class TokenVerifier:
         """
         Build a formatted authenticate string.
 
-        For example, A created string is the following format:
-        realm="https://token",service="docker.io",scope="repository:my-app:push".
+        For example, a created string will be the in following format:
+        realm="http://localhost:123/token",service="docker.io",scope="repository:app:push".
         """
-        realm = f'{self.request.scheme}://{settings.TOKEN_SERVER}'
-        authenticate_string = f'Bearer realm="{realm}",service="{settings.CONTENT_ORIGIN}"'
+        realm = settings.TOKEN_SERVER
+        authenticate_string = f'Bearer realm="{realm}",service="{CONTENT_HOST}"'
 
         if not self._is_verifying_root_endpoint():
             scope = f'repository:{source_path}:pull'
@@ -132,7 +135,7 @@ class TokenVerifier:
         return {
             'algorithms': [settings.TOKEN_SIGNATURE_ALGORITHM],
             'issuer': settings.TOKEN_SERVER,
-            'audience': settings.CONTENT_ORIGIN
+            'audience': CONTENT_HOST
         }
 
     def contains_accessible_actions(self, decoded_token):

--- a/template_config.yml
+++ b/template_config.yml
@@ -36,7 +36,7 @@ plugin_snake: pulp_container
 pulp_settings:
   private_key_path: /var/lib/pulp/tmp/private.pem
   public_key_path: /var/lib/pulp/tmp/public.pem
-  token_server: $(hostname):24816/token
+  token_server: http://$(hostname):24816/token
   token_signature_algorithm: ES256
 pulpcore_branch: master
 pydocstyle: true


### PR DESCRIPTION
In this commit, there was also updated the documentation. Before this commit, there was not mentioned that pulp_container expects a FQDN of a token server together with a port number. The additional setting CONTENT_HOST was created because the token server should expect only service names wihthout a scheme.

closes #5779
https://pulp.plan.io/issues/5779