### PR TITLE
Update classifiers in setup.py

### DIFF
--- a/CHANGES/5907.misc
+++ b/CHANGES/5907.misc
@@ -1,0 +1,1 @@
+Update classifiers in setup.py to mark GA release as production/stable.

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,7 @@ setup(
     classifiers=[
         'License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)',
         'Operating System :: POSIX :: Linux',
+        'Development Status :: 5 - Production/Stable',
         'Framework :: Django',
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',


### PR DESCRIPTION
Mark GA release as production/stable in setup.py classifiers.

fixes #5907
https://pulp.plan.io/issues/5907