### PR TITLE
Convert functional tests to use bindings

### DIFF
--- a/CHANGES/6069.misc
+++ b/CHANGES/6069.misc
@@ -1,0 +1,1 @@
+Functional tests now use bindings

--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,4 +1,1 @@
-ecdsa~=0.13.2
 git+https://github.com/pulp/pulp-smash.git#egg=pulp-smash
-pyjwkest~=1.4.0
-pulpcore>=3.0rc8,<3.2

--- a/pulp_container/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_container/tests/functional/api/test_crud_content_unit.py
@@ -2,15 +2,16 @@
 """Tests that CRUD container content units."""
 import unittest
 
-from requests.exceptions import HTTPError
-
-from pulp_smash import api, config, utils
-from pulp_smash.pulp3.constants import ARTIFACTS_PATH
 from pulp_smash.pulp3.utils import delete_orphans
 
-from pulp_container.tests.functional.constants import CONTAINER_IMAGE_URL, CONTAINER_CONTENT_PATH
-from pulp_container.tests.functional.utils import gen_container_image_attrs, skip_if
-from pulp_container.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+from pulp_container.tests.functional.utils import (
+    gen_artifact,
+    gen_container_client,
+    gen_container_content_attrs,
+    monitor_task,
+    skip_if,
+)
+from pulpcore.client.pulp_container import ContentManifestsApi
 
 
 # Read the instructions provided below for the steps needed to enable this test (see: FIXME's).
@@ -31,75 +32,81 @@ class ContentUnitTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create class-wide variable."""
-        cls.cfg = config.get_config()
-        delete_orphans(cls.cfg)
+        delete_orphans()
         cls.content_unit = {}
-        cls.client = api.Client(cls.cfg, api.json_handler)
-        files = {'file': utils.http_get(CONTAINER_IMAGE_URL)}
-        cls.artifact = cls.client.post(ARTIFACTS_PATH, files=files)
+
+        # FIXME: Instantiate APIs for all content types.
+        cls.container_content_api = ContentManifestsApi(gen_container_client())
+        cls.artifact = gen_artifact()
 
     @classmethod
     def tearDownClass(cls):
         """Clean class-wide variable."""
-        delete_orphans(cls.cfg)
+        delete_orphans()
 
     def test_01_create_content_unit(self):
         """Create content unit."""
-        attrs = gen_container_image_attrs(self.artifact)
-        self.content_unit.update(self.client.post(CONTAINER_CONTENT_PATH, attrs))
+        attrs = gen_container_content_attrs(self.artifact)
+        # FIXME: Currently, it is not possible to create or update a content unit via an
+        #  ordinary content type's endpoint. One must use a repository's endpoint for this.
+        response = self.container_content_api.create(**attrs)
+        created_resources = monitor_task(response.task)
+        content_unit = self.container_content_api.read(created_resources[0])
+        self.content_unit.update(content_unit.to_dict())
         for key, val in attrs.items():
             with self.subTest(key=key):
                 self.assertEqual(self.content_unit[key], val)
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_02_read_content_unit(self):
         """Read a content unit by its href."""
-        content_unit = self.client.get(self.content_unit['pulp_href'])
+        content_unit = self.container_content_api.read(self.content_unit["pulp_href"]).to_dict()
         for key, val in self.content_unit.items():
             with self.subTest(key=key):
                 self.assertEqual(content_unit[key], val)
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_02_read_content_units(self):
         """Read a content unit by its relative_path."""
         # FIXME: 'relative_path' is an attribute specific to the File plugin. It is only an
         # example. You should replace this with some other field specific to your content type.
-        page = self.client.get(CONTAINER_CONTENT_PATH, params={
-            'relative_path': self.content_unit['relative_path']
-        })
-        self.assertEqual(len(page['results']), 1)
+        page = self.container_content_api.list(relative_path=self.content_unit["relative_path"])
+        self.assertEqual(len(page.results), 1)
         for key, val in self.content_unit.items():
             with self.subTest(key=key):
-                self.assertEqual(page['results'][0][key], val)
+                self.assertEqual(page.results[0].to_dict()[key], val)
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_03_partially_update(self):
         """Attempt to update a content unit using HTTP PATCH.
 
         This HTTP method is not supported and a HTTP exception is expected.
         """
-        attrs = gen_container_image_attrs(self.artifact)
-        with self.assertRaises(HTTPError) as exc:
-            self.client.patch(self.content_unit['pulp_href'], attrs)
-        self.assertEqual(exc.exception.response.status_code, 405)
+        attrs = gen_container_content_attrs(self.artifact)
+        with self.assertRaises(AttributeError) as exc:
+            self.container_content_api.partial_update(self.content_unit["pulp_href"], attrs)
+        msg = "object has no attribute 'partial_update'"
+        self.assertIn(msg, exc.exception.args[0])
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_03_fully_update(self):
         """Attempt to update a content unit using HTTP PUT.
 
         This HTTP method is not supported and a HTTP exception is expected.
         """
-        attrs = gen_container_image_attrs(self.artifact)
-        with self.assertRaises(HTTPError) as exc:
-            self.client.put(self.content_unit['pulp_href'], attrs)
-        self.assertEqual(exc.exception.response.status_code, 405)
+        attrs = gen_container_content_attrs(self.artifact)
+        with self.assertRaises(AttributeError) as exc:
+            self.container_content_api.update(self.content_unit["pulp_href"], attrs)
+        msg = "object has no attribute 'update'"
+        self.assertIn(msg, exc.exception.args[0])
 
-    @skip_if(bool, 'content_unit', False)
+    @skip_if(bool, "content_unit", False)
     def test_04_delete(self):
         """Attempt to delete a content unit using HTTP DELETE.
 
         This HTTP method is not supported and a HTTP exception is expected.
         """
-        with self.assertRaises(HTTPError) as exc:
-            self.client.delete(self.content_unit['pulp_href'])
-        self.assertEqual(exc.exception.response.status_code, 405)
+        with self.assertRaises(AttributeError) as exc:
+            self.container_content_api.delete(self.content_unit["pulp_href"])
+        msg = "object has no attribute 'delete'"
+        self.assertIn(msg, exc.exception.args[0])

--- a/pulp_container/tests/functional/api/test_crud_remotes.py
+++ b/pulp_container/tests/functional/api/test_crud_remotes.py
@@ -3,17 +3,18 @@
 from random import choice
 import unittest
 
-from requests.exceptions import HTTPError
+from pulp_smash import utils
+from pulp_smash.pulp3.constants import ON_DEMAND_DOWNLOAD_POLICIES
 
-from pulp_smash import api, config, utils
-from pulp_smash.pulp3.constants import (
-    IMMEDIATE_DOWNLOAD_POLICIES,
-    ON_DEMAND_DOWNLOAD_POLICIES,
+from pulp_container.tests.functional.utils import (
+    gen_container_client,
+    gen_container_remote,
+    monitor_task,
+    skip_if,
 )
 
-from pulp_container.tests.functional.constants import CONTAINER_REMOTE_PATH
-from pulp_container.tests.functional.utils import skip_if, gen_container_remote
-from pulp_container.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
+from pulpcore.client.pulp_container import RemotesContainerApi
+from pulpcore.client.pulp_container.exceptions import ApiException
 
 
 class CRUDRemotesTestCase(unittest.TestCase):
@@ -22,21 +23,20 @@ class CRUDRemotesTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create class-wide variables."""
-        cls.cfg = config.get_config()
-        cls.client = api.Client(cls.cfg, api.json_handler)
-        cls.remote = {}
+        cls.remote_api = RemotesContainerApi(gen_container_client())
+        cls.remote = None
 
     def test_01_create_remote(self):
         """Create a remote."""
         body = _gen_verbose_remote()
-        type(self).remote = self.client.post(CONTAINER_REMOTE_PATH, body)
-        for key in ('username', 'password'):
+        type(self).remote = self.remote_api.create(body)
+        for key in ("username", "password"):
             del body[key]
         for key, val in body.items():
             with self.subTest(key=key):
-                self.assertEqual(self.remote[key], val)
+                self.assertEqual(self.remote.to_dict()[key], val, key)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_02_create_same_name(self):
         """Try to create a second remote with an identical name.
 
@@ -44,59 +44,60 @@ class CRUDRemotesTestCase(unittest.TestCase):
         <https://github.com/pulp/pulp-smash/issues/1055>`_.
         """
         body = gen_container_remote()
-        body['name'] = self.remote['name']
-        with self.assertRaises(HTTPError):
-            self.client.post(CONTAINER_REMOTE_PATH, body)
+        body["name"] = self.remote.name
+        with self.assertRaises(ApiException):
+            self.remote_api.create(body)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_02_read_remote(self):
         """Read a remote by its href."""
-        remote = self.client.get(self.remote['pulp_href'])
-        for key, val in self.remote.items():
+        remote = self.remote_api.read(self.remote.pulp_href)
+        for key, val in self.remote.to_dict().items():
             with self.subTest(key=key):
-                self.assertEqual(remote[key], val)
+                self.assertEqual(remote.to_dict()[key], val, key)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_02_read_remotes(self):
         """Read a remote by its name."""
-        page = self.client.get(CONTAINER_REMOTE_PATH, params={
-            'name': self.remote['name']
-        })
-        self.assertEqual(len(page['results']), 1)
-        for key, val in self.remote.items():
+        page = self.remote_api.list(name=self.remote.name)
+        self.assertEqual(len(page.results), 1)
+        for key, val in self.remote.to_dict().items():
             with self.subTest(key=key):
-                self.assertEqual(page['results'][0][key], val)
+                self.assertEqual(page.results[0].to_dict()[key], val, key)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_03_partially_update(self):
         """Update a remote using HTTP PATCH."""
         body = _gen_verbose_remote()
-        self.client.patch(self.remote['pulp_href'], body)
-        for key in ('username', 'password'):
+        response = self.remote_api.partial_update(self.remote.pulp_href, body)
+        monitor_task(response.task)
+        for key in ("username", "password"):
             del body[key]
-        type(self).remote = self.client.get(self.remote['pulp_href'])
+        type(self).remote = self.remote_api.read(self.remote.pulp_href)
         for key, val in body.items():
             with self.subTest(key=key):
-                self.assertEqual(self.remote[key], val)
+                self.assertEqual(self.remote.to_dict()[key], val, key)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_04_fully_update(self):
         """Update a remote using HTTP PUT."""
         body = _gen_verbose_remote()
-        self.client.put(self.remote['pulp_href'], body)
-        for key in ('username', 'password'):
+        response = self.remote_api.update(self.remote.pulp_href, body)
+        monitor_task(response.task)
+        for key in ("username", "password"):
             del body[key]
-        type(self).remote = self.client.get(self.remote['pulp_href'])
+        type(self).remote = self.remote_api.read(self.remote.pulp_href)
         for key, val in body.items():
             with self.subTest(key=key):
-                self.assertEqual(self.remote[key], val)
+                self.assertEqual(self.remote.to_dict()[key], val, key)
 
-    @skip_if(bool, 'remote', False)
+    @skip_if(bool, "remote", False)
     def test_05_delete(self):
         """Delete a remote."""
-        self.client.delete(self.remote['pulp_href'])
-        with self.assertRaises(HTTPError):
-            self.client.get(self.remote['pulp_href'])
+        response = self.remote_api.delete(self.remote.pulp_href)
+        monitor_task(response.task)
+        with self.assertRaises(ApiException):
+            self.remote_api.read(self.remote.pulp_href)
 
 
 class CreateRemoteNoURLTestCase(unittest.TestCase):
@@ -111,9 +112,90 @@ class CreateRemoteNoURLTestCase(unittest.TestCase):
         * `Pulp Smash #984 <https://github.com/pulp/pulp-smash/issues/984>`_
         """
         body = gen_container_remote()
-        del body['url']
-        with self.assertRaises(HTTPError):
-            api.Client(config.get_config()).post(CONTAINER_REMOTE_PATH, body)
+        del body["url"]
+        with self.assertRaises(ApiException):
+            RemotesContainerApi(gen_container_client()).create(body)
+
+
+class RemoteDownloadPolicyTestCase(unittest.TestCase):
+    """Verify download policy behavior for valid and invalid values.
+
+    In Pulp 3, there are are different download policies.
+
+    This test targets the following testing scenarios:
+
+    1. Creating a remote without a download policy.
+       Verify the creation is successful and immediate it is policy applied.
+    2. Change the remote policy from default.
+       Verify the change is successful.
+    3. Attempt to change the remote policy to an invalid string.
+       Verify an ApiException is given for the invalid policy as well
+       as the policy remaining unchanged.
+
+    For more information on the remote policies, see the Pulp3
+    API on an installed server:
+
+    * /pulp/api/v3/docs/#operation`
+
+    This test targets the following issues:
+
+    * `Pulp #4420 <https://pulp.plan.io/issues/4420>`_
+    * `Pulp #3763 <https://pulp.plan.io/issues/3763>`_
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        """Create class-wide variables."""
+        cls.remote_api = RemotesContainerApi(gen_container_client())
+        cls.remote = {}
+        cls.policies = ON_DEMAND_DOWNLOAD_POLICIES
+        cls.body = _gen_verbose_remote()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Clean class-wide variable."""
+        results = cls.remote_api.list().to_dict()["results"]
+        for result in results:
+            cls.remote_api.delete(result["pulp_href"])
+
+    def test_01_no_defined_policy(self):
+        """Verify the default policy `immediate`.
+
+        When no policy is defined, the default policy of `immediate`
+        is applied.
+        """
+        del self.body["policy"]
+        self.remote.update(self.remote_api.create(self.body).to_dict())
+        self.assertEqual(self.remote["policy"], "immediate", self.remote)
+
+    @skip_if(len, "policies", 1)
+    def test_02_change_policy(self):
+        """Verify ability to change policy to value other than the default.
+
+        Update the remote policy to a valid value other than `immedaite`
+        and verify the new set value.
+        """
+        changed_policy = choice([item for item in self.policies if item != "immediate"])
+        response = self.remote_api.partial_update(
+            self.remote["pulp_href"], {"policy": changed_policy}
+        )
+        monitor_task(response.task)
+        self.remote.update(self.remote_api.read(self.remote["pulp_href"]).to_dict())
+        self.assertEqual(self.remote["policy"], changed_policy, self.remote)
+
+    @skip_if(bool, "remote", False)
+    def test_03_invalid_policy(self):
+        """Verify an invalid policy does not update the remote policy.
+
+        Get the current remote policy.
+        Attempt to update the remote policy to an invalid value.
+        Verify the policy remains the same.
+        """
+        remote = self.remote_api.read(self.remote["pulp_href"]).to_dict()
+        with self.assertRaises(ApiException):
+            self.remote_api.partial_update(self.remote["pulp_href"], {"policy": utils.uuid4()})
+        self.remote.update(self.remote_api.read(self.remote["pulp_href"]).to_dict())
+        self.assertEqual(remote["policy"], self.remote["policy"], self.remote)
 
 
 def _gen_verbose_remote():
@@ -127,11 +209,10 @@ def _gen_verbose_remote():
     Note that 'username' and 'password' are write-only attributes.
     """
     attrs = gen_container_remote()
-    attrs.update({
-        'password': utils.uuid4(),
-        'username': utils.uuid4(),
-        'policy': choice(
-            IMMEDIATE_DOWNLOAD_POLICIES + ON_DEMAND_DOWNLOAD_POLICIES
-        ),
-    })
+    attrs.update(
+        {
+            "password": utils.uuid4(), "username": utils.uuid4(),
+            "policy": choice(ON_DEMAND_DOWNLOAD_POLICIES)
+        }
+    )
     return attrs

--- a/pulp_container/tests/functional/api/test_recursive_add.py
+++ b/pulp_container/tests/functional/api/test_recursive_add.py
@@ -2,18 +2,28 @@
 """Tests that recursively add container content to repositories."""
 import unittest
 
-from pulp_smash import api, config
-from pulp_smash.pulp3.utils import gen_repo, sync
-from requests.exceptions import HTTPError
+from pulp_smash.pulp3.utils import gen_repo
 
-from pulp_container.tests.functional.constants import (
-    CONTAINER_TAG_PATH,
-    CONTAINER_REMOTE_PATH,
-    CONTAINER_REPO_PATH,
-    DOCKERHUB_PULP_FIXTURE_1,
+from pulp_container.tests.functional.utils import (
+    gen_container_remote,
+    gen_container_client,
+    monitor_task,
 )
-from pulp_container.tests.functional.utils import gen_container_remote
+from pulp_container.tests.functional.constants import DOCKERHUB_PULP_FIXTURE_1
+
 from pulp_container.constants import MEDIA_TYPE
+
+from pulpcore.client.pulp_container import (
+    ApiException,
+    ContainerContainerRemote,
+    ContainerContainerRepository,
+    ContentTagsApi,
+    ContentManifestsApi,
+    RemotesContainerApi,
+    RepositoriesContainerApi,
+    RepositoriesContainerVersionsApi,
+    RepositorySyncURL,
+)
 
 
 class TestManifestCopy(unittest.TestCase):
@@ -27,244 +37,294 @@ class TestManifestCopy(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Sync pulp/test-fixture-1 so we can copy content from it."""
-        cls.cfg = config.get_config()
-        cls.client = api.Client(cls.cfg, api.json_handler)
-        cls.from_repo = cls.client.post(CONTAINER_REPO_PATH, gen_repo())
+        api_client = gen_container_client()
+        cls.repositories_api = RepositoriesContainerApi(api_client)
+        cls.versions_api = RepositoriesContainerVersionsApi(api_client)
+        cls.remotes_api = RemotesContainerApi(api_client)
+        cls.tags_api = ContentTagsApi(api_client)
+        cls.manifests_api = ContentManifestsApi(api_client)
+
+        cls.from_repo = cls.repositories_api.create(ContainerContainerRepository(**gen_repo()))
+
         remote_data = gen_container_remote(upstream_name=DOCKERHUB_PULP_FIXTURE_1)
-        cls.remote = cls.client.post(CONTAINER_REMOTE_PATH, remote_data)
-        sync(cls.cfg, cls.remote, cls.from_repo)
-        latest_version = cls.client.get(cls.from_repo['pulp_href'])['latest_version_href']
-        cls.latest_from_version = "repository_version={version}".format(version=latest_version)
+        cls.remote = cls.remotes_api.create(ContainerContainerRemote(**remote_data))
+
+        sync_data = RepositorySyncURL(remote=cls.remote.pulp_href)
+        sync_response = cls.repositories_api.sync(cls.from_repo.pulp_href, sync_data)
+        monitor_task(sync_response.task)
+
+        cls.latest_from_version = cls.repositories_api.read(
+            cls.from_repo.pulp_href
+        ).latest_version_href
 
     def setUp(self):
         """Create an empty repository to copy into."""
-        self.to_repo = self.client.post(CONTAINER_REPO_PATH, gen_repo())
-        self.CONTAINER_MANIFEST_COPY_PATH = f'{self.to_repo["pulp_href"]}copy_manifests/'
-        self.addCleanup(self.client.delete, self.to_repo['pulp_href'])
+        self.to_repo = self.repositories_api.create(ContainerContainerRepository(**gen_repo()))
+        self.addCleanup(self.repositories_api.delete, self.to_repo.pulp_href)
 
     @classmethod
     def tearDownClass(cls):
         """Delete things made in setUpClass. addCleanup feature does not work with setupClass."""
-        cls.client.delete(cls.from_repo['pulp_href'])
-        cls.client.delete(cls.remote['pulp_href'])
+        cls.repositories_api.delete(cls.from_repo.pulp_href)
+        cls.repositories_api.delete(cls.remote.pulp_href)
 
     def test_missing_repository_argument(self):
         """Ensure source_repository or source_repository_version is required."""
-        with self.assertRaises(HTTPError) as context:
-            self.client.post(self.CONTAINER_MANIFEST_COPY_PATH)
-        self.assertEqual(context.exception.response.status_code, 400)
+        with self.assertRaises(ApiException) as context:
+            self.repositories_api.copy_manifests(self.to_repo.pulp_href, {})
+        self.assertEqual(context.exception.status, 400)
 
     def test_empty_source_repository(self):
         """Ensure exception is raised when source_repository does not have latest version."""
-        self.client.delete(self.to_repo['latest_version_href'])
-        with self.assertRaises(HTTPError) as context:
-            self.client.post(
-                self.CONTAINER_MANIFEST_COPY_PATH,
+        delete_response = self.repositories_api.delete(self.to_repo.latest_version_href)
+        monitor_task(delete_response.task)
+        with self.assertRaises(ApiException) as context:
+            self.repositories_api.copy_manifests(
+                self.to_repo.pulp_href,
                 {
                     # to_repo has no versions, use it as source
-                    'source_repository': self.to_repo['pulp_href'],
+                    "source_repository": self.to_repo.pulp_href,
                 }
             )
-        self.assertEqual(context.exception.response.status_code, 400)
+        self.assertEqual(context.exception.status, 400)
 
     def test_source_repository_and_source_version(self):
         """Passing source_repository_version and repository returns a 400."""
-        with self.assertRaises(HTTPError) as context:
-            self.client.post(
-                self.CONTAINER_MANIFEST_COPY_PATH,
+        with self.assertRaises(ApiException) as context:
+            self.repositories_api.copy_manifests(
+                self.to_repo.pulp_href,
                 {
-                    'source_repository': self.from_repo['pulp_href'],
-                    'source_repository_version': self.from_repo['latest_version_href'],
+                    "source_repository": self.from_repo.pulp_href,
+                    "source_repository_version": self.from_repo.latest_version_href,
                 }
             )
-        self.assertEqual(context.exception.response.status_code, 400)
+        self.assertEqual(context.exception.status, 400)
 
     def test_copy_all_manifests(self):
         """Passing only source repository copies all manifests."""
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        copy_response = self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
+                "source_repository": self.from_repo.pulp_href,
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest_from_repo_href = self.client.get(self.from_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        from_repo_content = self.client.get(latest_from_repo_href)['content_summary']['present']
-        for container_type in ['container.manifest', 'container.blob']:
+        monitor_task(copy_response.task)
+
+        latest_to = self.repositories_api.read(self.to_repo.pulp_href)
+        latest_from = self.repositories_api.read(self.from_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            latest_to.latest_version_href
+        ).content_summary.present
+        from_repo_content = self.versions_api.read(
+            latest_from.latest_version_href
+        ).content_summary.present
+        for container_type in ["container.manifest", "container.blob"]:
             self.assertEqual(
-                to_repo_content[container_type]['count'],
-                from_repo_content[container_type]['count'],
+                to_repo_content[container_type]["count"],
+                from_repo_content[container_type]["count"],
                 msg=container_type,
             )
-        self.assertFalse('container.tag' in to_repo_content)
+        self.assertFalse("container.tag" in to_repo_content)
 
     def test_copy_all_manifests_from_version(self):
         """Passing only source version copies all manifests."""
-        latest_from_repo_href = self.client.get(self.from_repo['pulp_href'])['latest_version_href']
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        latest_from = self.repositories_api.read(self.from_repo.pulp_href)
+        copy_response = self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository_version': latest_from_repo_href,
+                "source_repository_version": latest_from.latest_version_href,
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        from_repo_content = self.client.get(latest_from_repo_href)['content_summary']['present']
-        for container_type in ['container.manifest', 'container.blob']:
+        monitor_task(copy_response.task)
+
+        latest_to = self.repositories_api.read(self.to_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            latest_to.latest_version_href
+        ).content_summary.present
+        from_repo_content = self.versions_api.read(
+            latest_from.latest_version_href
+        ).content_summary.present
+        for container_type in ["container.manifest", "container.blob"]:
             self.assertEqual(
-                to_repo_content[container_type]['count'],
-                from_repo_content[container_type]['count']
+                to_repo_content[container_type]["count"],
+                from_repo_content[container_type]["count"]
             )
-        self.assertFalse('container.tag' in to_repo_content)
+        self.assertFalse("container.tag" in to_repo_content)
 
     def test_copy_manifest_by_digest(self):
         """Specify a single manifest by digest to copy."""
-        manifest_a_href = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        manifest_a_digest = self.client.get(manifest_a_href)['digest']
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        manifest_a_href = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        manifest_a_digest = self.manifests_api.read(manifest_a_href).digest
+        copy_response = self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'digests': [manifest_a_digest]
+                "source_repository": self.from_repo.pulp_href,
+                "digests": [manifest_a_digest]
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        self.assertFalse('container.tag' in to_repo_content)
-        self.assertEqual(to_repo_content['container.manifest']['count'], 1)
+        monitor_task(copy_response.task)
+
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary.present
+        self.assertFalse("container.tag" in to_repo_content)
+        self.assertEqual(to_repo_content["container.manifest"]["count"], "1")
         # manifest_a has 2 blobs
-        self.assertEqual(to_repo_content['container.blob']['count'], 2)
+        self.assertEqual(to_repo_content["container.blob"]["count"], "2")
 
     def test_copy_manifest_by_digest_and_media_type(self):
         """Specify a single manifest by digest to copy."""
-        manifest_a_href = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        manifest_a_digest = self.client.get(manifest_a_href)['digest']
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        manifest_a_href = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        manifest_a_digest = self.manifests_api.read(manifest_a_href).digest
+        copy_response = self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'digests': [manifest_a_digest],
-                'media_types': [MEDIA_TYPE.MANIFEST_V2]
+                "source_repository": self.from_repo.pulp_href,
+                "digests": [manifest_a_digest],
+                "media_types": [MEDIA_TYPE.MANIFEST_V2]
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        self.assertFalse('container.tag' in to_repo_content)
-        self.assertEqual(to_repo_content['container.manifest']['count'], 1)
+        monitor_task(copy_response.task)
+
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary.present
+        self.assertFalse("container.tag" in to_repo_content)
+        self.assertEqual(to_repo_content["container.manifest"]["count"], "1")
         # manifest_a has 2 blobs
-        self.assertEqual(to_repo_content['container.blob']['count'], 2)
+        self.assertEqual(to_repo_content["container.blob"]["count"], "2")
 
     def test_copy_all_manifest_lists_by_media_type(self):
         """Specify the media_type, to copy all manifest lists."""
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        copy_response = self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'media_types': [MEDIA_TYPE.MANIFEST_LIST]
+                "source_repository": self.from_repo.pulp_href,
+                "media_types": [MEDIA_TYPE.MANIFEST_LIST]
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        self.assertFalse('container.tag' in to_repo_content)
+        monitor_task(copy_response.task)
+
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary.present
+        self.assertFalse("container.tag" in to_repo_content)
         # Fixture has 4 manifest lists, which combined reference 5 manifests
-        self.assertEqual(to_repo_content['container.manifest']['count'], 9)
+        self.assertEqual(to_repo_content["container.manifest"]["count"], "9")
         # each manifest (non-list) has 2 blobs
-        self.assertEqual(to_repo_content['container.blob']['count'], 10)
+        self.assertEqual(to_repo_content["container.blob"]["count"], "10")
 
     def test_copy_all_manifests_by_media_type(self):
         """Specify the media_type, to copy all manifest lists."""
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        copy_response = self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'media_types': [MEDIA_TYPE.MANIFEST_V1, MEDIA_TYPE.MANIFEST_V2]
+                "source_repository": self.from_repo.pulp_href,
+                "media_types": [MEDIA_TYPE.MANIFEST_V1, MEDIA_TYPE.MANIFEST_V2]
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        self.assertFalse('container.tag' in to_repo_content)
+        monitor_task(copy_response.task)
+
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary.present
+        self.assertFalse("container.tag" in to_repo_content)
         # Fixture has 5 manifests that aren't manifest lists
-        self.assertEqual(to_repo_content['container.manifest']['count'], 5)
+        self.assertEqual(to_repo_content["container.manifest"]["count"], "5")
         # each manifest (non-list) has 2 blobs
-        self.assertEqual(to_repo_content['container.blob']['count'], 10)
+        self.assertEqual(to_repo_content["container.blob"]["count"], "10")
 
     def test_fail_to_copy_invalid_manifest_media_type(self):
         """Specify the media_type, to copy all manifest lists."""
-        with self.assertRaises(HTTPError) as context:
-            self.client.post(
-                self.CONTAINER_MANIFEST_COPY_PATH,
+        with self.assertRaises(ApiException) as context:
+            self.repositories_api.copy_manifests(
+                self.to_repo.pulp_href,
                 {
-                    'source_repository': self.from_repo['pulp_href'],
-                    'media_types': ['wrongwrongwrong']
+                    "source_repository": self.from_repo.pulp_href,
+                    "media_types": ["wrongwrongwrong"]
                 }
             )
-        self.assertEqual(context.exception.response.status_code, 400)
+        self.assertEqual(context.exception.status, 400)
 
     def test_copy_by_digest_with_incorrect_media_type(self):
         """Ensure invalid media type will raise a 400."""
-        ml_i_href = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        ml_i_digest = self.client.get(ml_i_href)['digest']
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        ml_i_href = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        ml_i_digest = self.manifests_api.read(ml_i_href).digest
+
+        copy_response = self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'digests': [ml_i_digest],
-                'media_types': [MEDIA_TYPE.MANIFEST_V2]
+                "source_repository": self.from_repo.pulp_href,
+                "digests": [ml_i_digest],
+                "media_types": [MEDIA_TYPE.MANIFEST_V2]
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
+        monitor_task(copy_response.task)
+
+        latest_to_repo_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
         # Assert no version created
-        self.assertEqual(latest_to_repo_href, f"{self.to_repo['pulp_href']}versions/0/")
+        self.assertEqual(latest_to_repo_href, f"{self.to_repo.pulp_href}versions/0/")
 
     def test_copy_multiple_manifests_by_digest(self):
         """Specify digests to copy."""
-        ml_i_href = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        ml_i_digest = self.client.get(ml_i_href)['digest']
-        ml_ii_href = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_ii&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        ml_ii_digest = self.client.get(ml_ii_href)['digest']
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        ml_i_href = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        ml_i_digest = self.manifests_api.read(ml_i_href).digest
+
+        ml_ii_href = self.tags_api.list(
+            name="ml_ii",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        ml_ii_digest = self.manifests_api.read(ml_ii_href).digest
+
+        copy_response = self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'digests': [ml_i_digest, ml_ii_digest]
+                "source_repository": self.from_repo.pulp_href,
+                "digests": [ml_i_digest, ml_ii_digest]
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        self.assertFalse('container.tag' in to_repo_content)
+        monitor_task(copy_response.task)
+
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary.present
+        self.assertFalse("container.tag" in to_repo_content)
         # each manifest list is a manifest and references 2 other manifests
-        self.assertEqual(to_repo_content['container.manifest']['count'], 6)
+        self.assertEqual(to_repo_content["container.manifest"]["count"], "6")
         # each referenced manifest has 2 blobs
-        self.assertEqual(to_repo_content['container.blob']['count'], 8)
+        self.assertEqual(to_repo_content["container.blob"]["count"], "8")
 
     def test_copy_manifests_by_digest_empty_list(self):
         """Passing an empty list copies no manifests."""
-        self.client.post(
-            self.CONTAINER_MANIFEST_COPY_PATH,
+        self.repositories_api.copy_manifests(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'digests': []
+                "source_repository": self.from_repo.pulp_href,
+                "digests": []
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
+        latest_to = self.repositories_api.read(self.to_repo.pulp_href)
         # Assert a new version was not created
-        self.assertEqual(latest_to_repo_href, f"{self.to_repo['pulp_href']}versions/0/")
+        self.assertEqual(latest_to.latest_version_href, f"{self.to_repo.pulp_href}versions/0/")
 
 
 class TestTagCopy(unittest.TestCase):
@@ -273,171 +333,206 @@ class TestTagCopy(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Sync pulp/test-fixture-1 so we can copy content from it."""
-        cls.cfg = config.get_config()
-        cls.client = api.Client(cls.cfg, api.json_handler)
-        cls.from_repo = cls.client.post(CONTAINER_REPO_PATH, gen_repo())
+        api_client = gen_container_client()
+        cls.repositories_api = RepositoriesContainerApi(api_client)
+        cls.remotes_api = RemotesContainerApi(api_client)
+        cls.versions_api = RepositoriesContainerVersionsApi(api_client)
+        cls.tags_api = ContentTagsApi(api_client)
+        cls.manifests_api = ContentManifestsApi(api_client)
+
+        repository_data = ContainerContainerRepository(**gen_repo())
+        cls.from_repo = cls.repositories_api.create(repository_data)
+
         remote_data = gen_container_remote(upstream_name=DOCKERHUB_PULP_FIXTURE_1)
-        cls.remote = cls.client.post(CONTAINER_REMOTE_PATH, remote_data)
-        sync(cls.cfg, cls.remote, cls.from_repo)
-        latest_version = cls.client.get(cls.from_repo['pulp_href'])['latest_version_href']
-        cls.latest_from_version = "repository_version={version}".format(version=latest_version)
+        cls.remote = cls.remotes_api.create(ContainerContainerRemote(**remote_data))
+
+        sync_data = RepositorySyncURL(remote=cls.remote.pulp_href)
+        sync_response = cls.repositories_api.sync(cls.from_repo.pulp_href, sync_data)
+        monitor_task(sync_response.task)
+
+        cls.latest_from_version = cls.repositories_api.read(
+            cls.from_repo.pulp_href
+        ).latest_version_href
 
     def setUp(self):
         """Create an empty repository to copy into."""
-        self.to_repo = self.client.post(CONTAINER_REPO_PATH, gen_repo())
-        self.CONTAINER_TAG_COPY_PATH = f'{self.to_repo["pulp_href"]}copy_tags/'
-        self.addCleanup(self.client.delete, self.to_repo['pulp_href'])
+        self.to_repo = self.repositories_api.create(gen_repo())
+        self.addCleanup(self.repositories_api.delete, self.to_repo.pulp_href)
 
     @classmethod
     def tearDownClass(cls):
         """Delete things made in setUpClass. addCleanup feature does not work with setupClass."""
-        cls.client.delete(cls.from_repo['pulp_href'])
-        cls.client.delete(cls.remote['pulp_href'])
+        cls.repositories_api.delete(cls.from_repo.pulp_href)
+        cls.remotes_api.delete(cls.remote.pulp_href)
 
     def test_missing_repository_argument(self):
         """Ensure source_repository or source_repository_version is required."""
-        with self.assertRaises(HTTPError):
-            self.client.post(self.CONTAINER_TAG_COPY_PATH)
+        with self.assertRaises(ApiException):
+            self.repositories_api.copy_tags(self.to_repo.pulp_href, {})
 
     def test_empty_source_repository(self):
         """Ensure exception is raised when source_repository does not have latest version."""
-        self.client.delete(self.to_repo['latest_version_href'])
-        with self.assertRaises(HTTPError):
-            self.client.post(
-                self.CONTAINER_TAG_COPY_PATH,
+        delete_response = self.repositories_api.delete(self.to_repo.latest_version_href)
+        monitor_task(delete_response.task)
+        with self.assertRaises(ApiException):
+            self.repositories_api.copy_tags(
+                self.to_repo.pulp_href,
                 {
                     # to_repo has no versions, use it as source
-                    'source_repository': self.to_repo['pulp_href'],
+                    "source_repository": self.to_repo.pulp_href,
                 }
             )
 
     def test_source_repository_and_source_version(self):
         """Passing both source_repository_version and source_repository returns a 400."""
-        with self.assertRaises(HTTPError) as context:
-            self.client.post(
-                self.CONTAINER_TAG_COPY_PATH,
+        with self.assertRaises(ApiException) as context:
+            self.repositories_api.copy_tags(
+                self.to_repo.pulp_href,
                 {
-                    'source_repository': self.from_repo['pulp_href'],
-                    'source_repository_version': self.from_repo['latest_version_href'],
+                    "source_repository": self.from_repo.pulp_href,
+                    "source_repository_version": self.from_repo.latest_version_href,
                 }
             )
-        self.assertEqual(context.exception.response.status_code, 400)
+        self.assertEqual(context.exception.status, 400)
 
     def test_copy_all_tags(self):
         """Passing only source and destination repositories copies all tags."""
-        self.client.post(
-            self.CONTAINER_TAG_COPY_PATH,
+        copy_response = self.repositories_api.copy_tags(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
+                "source_repository": self.from_repo.pulp_href,
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest_from_repo_href = self.client.get(self.from_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        from_repo_content = self.client.get(latest_from_repo_href)['content_summary']['present']
-        for container_type in ['container.tag', 'container.manifest', 'container.blob']:
+        monitor_task(copy_response.task)
+
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        from_repo = self.repositories_api.read(self.from_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary.present
+        from_repo_content = self.versions_api.read(
+            from_repo.latest_version_href
+        ).content_summary.present
+        for container_type in ["container.tag", "container.manifest", "container.blob"]:
             self.assertEqual(
-                to_repo_content[container_type]['count'],
-                from_repo_content[container_type]['count'],
+                to_repo_content[container_type]["count"],
+                from_repo_content[container_type]["count"],
                 msg=container_type,
             )
 
     def test_copy_all_tags_from_version(self):
         """Passing only source version and destination repositories copies all tags."""
-        latest_from_repo_href = self.client.get(self.from_repo['pulp_href'])['latest_version_href']
-        self.client.post(
-            self.CONTAINER_TAG_COPY_PATH,
+        latest_from_repo_href = self.repositories_api.read(
+            self.from_repo.pulp_href
+        ).latest_version_href
+        copy_response = self.repositories_api.copy_tags(
+            self.to_repo.pulp_href,
             {
-                'source_repository_version': latest_from_repo_href,
+                "source_repository_version": latest_from_repo_href,
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        from_repo_content = self.client.get(latest_from_repo_href)['content_summary']['present']
-        for container_type in ['container.tag', 'container.manifest', 'container.blob']:
+        monitor_task(copy_response.task)
+
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary.present
+        from_repo_content = self.versions_api.read(
+            latest_from_repo_href
+        ).content_summary.present
+        for container_type in ["container.tag", "container.manifest", "container.blob"]:
             self.assertEqual(
-                to_repo_content[container_type]['count'],
-                from_repo_content[container_type]['count'],
+                to_repo_content[container_type]["count"],
+                from_repo_content[container_type]["count"],
                 msg=container_type,
             )
 
     def test_copy_tags_by_name(self):
         """Copy tags in destination repo that match name."""
-        self.client.post(
-            self.CONTAINER_TAG_COPY_PATH,
+        copy_response = self.repositories_api.copy_tags(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'names': ['ml_i', 'manifest_c']
+                "source_repository": self.from_repo.pulp_href,
+                "names": ["ml_i", "manifest_c"]
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']['present']
-        self.assertEqual(to_repo_content['container.tag']['count'], 2)
+        monitor_task(copy_response.task)
+
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary.present
+        self.assertEqual(to_repo_content["container.tag"]["count"], "2")
         # ml_i has 1 manifest list, 2 manifests, manifest_c has 1 manifest
-        self.assertEqual(to_repo_content['container.manifest']['count'], 4)
+        self.assertEqual(to_repo_content["container.manifest"]["count"], "4")
         # each manifest (not manifest list) has 2 blobs
-        self.assertEqual(to_repo_content['container.blob']['count'], 6)
+        self.assertEqual(to_repo_content["container.blob"]["count"], "6")
 
     def test_copy_tags_by_name_empty_list(self):
         """Passing an empty list of names copies nothing."""
-        self.client.post(
-            self.CONTAINER_TAG_COPY_PATH,
+        copy_response = self.repositories_api.copy_tags(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
-                'names': []
+                "source_repository": self.from_repo.pulp_href,
+                "names": []
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
+        monitor_task(copy_response.task)
+
+        latest_to_repo_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
         # Assert a new version was not created
-        self.assertEqual(latest_to_repo_href, f"{self.to_repo['pulp_href']}versions/0/")
+        self.assertEqual(latest_to_repo_href, f"{self.to_repo.pulp_href}versions/0/")
 
     def test_copy_tags_with_conflicting_names(self):
         """If tag names are already present in a repository, the conflicting tags are removed."""
-        self.client.post(
-            self.CONTAINER_TAG_COPY_PATH,
+        copy_response = self.repositories_api.copy_tags(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
+                "source_repository": self.from_repo.pulp_href,
             }
         )
+        monitor_task(copy_response.task)
         # Tag the 'manifest_b' manifest as 'manifest_a'
-        latest_version = self.client.get(
-            self.to_repo['pulp_href']
-        )['latest_version_href']
-        manifest_b_href = self.client.get('{unit_path}?{filters}'.format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters=f'name=manifest_b&repository_version={latest_version}'
-        ))['results'][0]['tagged_manifest']
-        manifest_b = self.client.get(manifest_b_href)
+        latest_version_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
+        manifest_b_href = self.tags_api.list(
+            name="manifest_b",
+            repository_version=latest_version_href
+        ).results[0].tagged_manifest
+        manifest_b = self.manifests_api.read(manifest_b_href)
         params = {
-            'tag': 'manifest_a',
-            'digest': manifest_b['digest']
+            "tag": "manifest_a",
+            "digest": manifest_b.digest
         }
-        self.client.post(f'{self.to_repo["pulp_href"]}tag/', params)
+        tag_response = self.repositories_api.tag(self.to_repo.pulp_href, params)
+        monitor_task(tag_response.task)
         # Copy tags again from the original repo
-        self.client.post(
-            self.CONTAINER_TAG_COPY_PATH,
+        copy_response = self.repositories_api.copy_tags(
+            self.to_repo.pulp_href,
             {
-                'source_repository': self.from_repo['pulp_href'],
+                "source_repository": self.from_repo.pulp_href,
             }
         )
-        latest_to_repo_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest_from_repo_href = self.client.get(self.from_repo['pulp_href'])['latest_version_href']
-        to_repo_content = self.client.get(latest_to_repo_href)['content_summary']
-        from_repo_content = self.client.get(latest_from_repo_href)['content_summary']
-        for container_type in ['container.tag', 'container.manifest', 'container.blob']:
+        monitor_task(copy_response.task)
+        to_repo = self.repositories_api.read(self.to_repo.pulp_href)
+        from_repo = self.repositories_api.read(self.from_repo.pulp_href)
+        to_repo_content = self.versions_api.read(
+            to_repo.latest_version_href
+        ).content_summary
+        from_repo_content = self.versions_api.read(
+            from_repo.latest_version_href
+        ).content_summary
+        for container_type in ["container.tag", "container.manifest", "container.blob"]:
             self.assertEqual(
-                to_repo_content['present'][container_type]['count'],
-                from_repo_content['present'][container_type]['count']
+                to_repo_content.present[container_type]["count"],
+                from_repo_content.present[container_type]["count"]
             )
 
-        self.assertEqual(
-            to_repo_content['added']['container.tag']['count'],
-            1
-        )
-        self.assertEqual(
-            to_repo_content['removed']['container.tag']['count'],
-            1
-        )
+        self.assertEqual(to_repo_content.added["container.tag"]["count"], "1")
+        self.assertEqual(to_repo_content.removed["container.tag"]["count"], "1")
 
 
 class TestRecursiveAdd(unittest.TestCase):
@@ -446,164 +541,200 @@ class TestRecursiveAdd(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Sync pulp/test-fixture-1 so we can copy content from it."""
-        cls.cfg = config.get_config()
-        cls.client = api.Client(cls.cfg, api.json_handler)
-        cls.from_repo = cls.client.post(CONTAINER_REPO_PATH, gen_repo())
+        api_client = gen_container_client()
+        cls.repositories_api = RepositoriesContainerApi(api_client)
+        cls.remotes_api = RemotesContainerApi(api_client)
+        cls.tags_api = ContentTagsApi(api_client)
+        cls.versions_api = RepositoriesContainerVersionsApi(api_client)
+        cls.manifests_api = ContentManifestsApi(api_client)
+
+        repository_data = ContainerContainerRepository(**gen_repo())
+        cls.from_repo = cls.repositories_api.create(repository_data)
+
         remote_data = gen_container_remote(upstream_name=DOCKERHUB_PULP_FIXTURE_1)
-        cls.remote = cls.client.post(CONTAINER_REMOTE_PATH, remote_data)
-        sync(cls.cfg, cls.remote, cls.from_repo)
-        latest_version = cls.client.get(cls.from_repo['pulp_href'])['latest_version_href']
-        cls.latest_from_version = "repository_version={version}".format(version=latest_version)
+        cls.remote = cls.remotes_api.create(ContainerContainerRemote(**remote_data))
+
+        sync_data = RepositorySyncURL(remote=cls.remote.pulp_href)
+        sync_response = cls.repositories_api.sync(cls.from_repo.pulp_href, sync_data)
+        monitor_task(sync_response.task)
+
+        cls.latest_from_version = cls.repositories_api.read(
+            cls.from_repo.pulp_href
+        ).latest_version_href
 
     def setUp(self):
         """Create an empty repository to copy into."""
-        self.to_repo = self.client.post(CONTAINER_REPO_PATH, gen_repo())
-        self.CONTAINER_RECURSIVE_ADD_PATH = f'{self.to_repo["pulp_href"]}add/'
-        self.addCleanup(self.client.delete, self.to_repo['pulp_href'])
+        self.to_repo = self.repositories_api.create(gen_repo())
+        self.addCleanup(self.repositories_api.delete, self.to_repo.pulp_href)
 
     @classmethod
     def tearDownClass(cls):
         """Delete things made in setUpClass. addCleanup feature does not work with setupClass."""
-        cls.client.delete(cls.from_repo['pulp_href'])
-        cls.client.delete(cls.remote['pulp_href'])
+        cls.repositories_api.delete(cls.from_repo.pulp_href)
+        cls.remotes_api.delete(cls.remote.pulp_href)
 
     def test_repository_only(self):
         """Passing only a repository does not create a new version."""
-        self.client.post(self.CONTAINER_RECURSIVE_ADD_PATH)
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        self.assertEqual(latest_version_href, self.to_repo['latest_version_href'])
+        add_response = self.repositories_api.add(self.to_repo.pulp_href, {})
+        monitor_task(add_response.task)
+
+        latest_version_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
+        self.assertEqual(latest_version_href, self.to_repo.latest_version_href)
 
     def test_manifest_recursion(self):
         """Add a manifest and its related blobs."""
-        manifest_a = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [manifest_a]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        manifest_a = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
         # No tags added
-        self.assertFalse('container.manifest-tag' in latest['content_summary']['added'])
+        self.assertFalse("container.manifest-tag" in latest.content_summary.added)
 
         # manifest a has 2 blobs
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 2)
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "2")
 
     def test_manifest_list_recursion(self):
         """Add a Manifest List, related manifests, and related blobs."""
-        ml_i = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [ml_i]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        ml_i = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version,
+        ).results[0].tagged_manifest
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [ml_i]})
+        monitor_task(add_response.task)
+
+        latest_version_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
         # No tags added
-        self.assertFalse('container.tag' in latest['content_summary']['added'])
+        self.assertFalse("container.tag" in latest.content_summary.added)
         # 1 manifest list 2 manifests
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 3)
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "3")
 
     def test_tagged_manifest_list_recursion(self):
         """Add a tagged manifest list, and its related manifests and blobs."""
-        ml_i_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [ml_i_tag]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertEqual(latest['content_summary']['added']['container.tag']['count'], 1)
+        ml_i_tag = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [ml_i_tag]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertEqual(latest.content_summary.added["container.tag"]["count"], "1")
         # 1 manifest list 2 manifests
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 3)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 4)
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "3")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "4")
 
     def test_tagged_manifest_recursion(self):
         """Add a tagged manifest and its related blobs."""
-        manifest_a_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [manifest_a_tag]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        manifest_a_tag = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a_tag]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
-        self.assertEqual(latest['content_summary']['added']['container.tag']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 2)
+        self.assertEqual(latest.content_summary.added["container.tag"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "2")
 
     def test_tag_replacement(self):
         """Add a tagged manifest to a repo with a tag of that name already in place."""
-        manifest_a_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
+        manifest_a_tag = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
 
         # Add manifest_b to the repo
-        manifest_b = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_b&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        manifest_b_digest = self.client.get(manifest_b)['digest']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [manifest_b]})
+        manifest_b = self.tags_api.list(
+            name="manifest_b",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        manifest_b_digest = self.manifests_api.read(manifest_b).digest
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_b]})
+        monitor_task(add_response.task)
         # Tag manifest_b as `manifest_a`
         params = {
-            'tag': "manifest_a",
-            'digest': manifest_b_digest
+            "tag": "manifest_a",
+            "digest": manifest_b_digest
         }
-        self.client.post(f'{self.to_repo["pulp_href"]}tag/', params)
+        self.repositories_api.tag(self.to_repo.pulp_href, params)
 
         # Now add original manifest_a tag to the repo, which should remove the
         # new manifest_a tag, but leave the tagged manifest (manifest_b)
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [manifest_a_tag]})
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a_tag]})
+        monitor_task(add_response.task)
 
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertEqual(latest['content_summary']['added']['container.tag']['count'], 1)
-        self.assertEqual(latest['content_summary']['removed']['container.tag']['count'], 1)
-        self.assertFalse('container.manifest' in latest['content_summary']['removed'])
-        self.assertFalse('container.blob' in latest['content_summary']['removed'])
+        latest_version_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertEqual(latest.content_summary.added["container.tag"]["count"], "1")
+        self.assertEqual(latest.content_summary.removed["container.tag"]["count"], "1")
+        self.assertFalse("container.manifest" in latest.content_summary.removed)
+        self.assertFalse("container.blob" in latest.content_summary.removed)
 
     def test_many_tagged_manifest_lists(self):
         """Add several Manifest List, related manifests, and related blobs."""
-        ml_i_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        ml_ii_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_ii&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        ml_iii_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_iii&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        ml_iv_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_iv&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
+        ml_i_tag = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        ml_ii_tag = self.tags_api.list(
+            name="ml_ii",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        ml_iii_tag = self.tags_api.list(
+            name="ml_iii",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        ml_iv_tag = self.tags_api.list(
+            name="ml_iv",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
             {
-                'content_units': [ml_i_tag, ml_ii_tag, ml_iii_tag, ml_iv_tag]
+                "content_units": [ml_i_tag, ml_ii_tag, ml_iii_tag, ml_iv_tag]
             }
         )
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        monitor_task(add_response.task)
 
-        self.assertEqual(latest['content_summary']['added']['container.tag']['count'], 4)
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 9)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 10)
+        latest_version_href = self.repositories_api.read(
+            self.to_repo.pulp_href
+        ).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+
+        self.assertEqual(latest.content_summary.added["container.tag"]["count"], "4")
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "9")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "10")

--- a/pulp_container/tests/functional/api/test_recursive_remove.py
+++ b/pulp_container/tests/functional/api/test_recursive_remove.py
@@ -2,17 +2,25 @@
 """Tests that recursively remove container content from repositories."""
 import unittest
 
-from pulp_smash import api, config
-from pulp_smash.pulp3.utils import gen_repo, sync
-from requests.exceptions import HTTPError
+from pulp_smash.pulp3.utils import gen_repo
 
-from pulp_container.tests.functional.constants import (
-    CONTAINER_TAG_PATH,
-    CONTAINER_REMOTE_PATH,
-    CONTAINER_REPO_PATH,
-    DOCKERHUB_PULP_FIXTURE_1,
+from pulp_container.tests.functional.utils import (
+    gen_container_remote,
+    gen_container_client,
+    monitor_task,
 )
-from pulp_container.tests.functional.utils import gen_container_remote
+from pulp_container.tests.functional.constants import DOCKERHUB_PULP_FIXTURE_1
+
+from pulpcore.client.pulp_container import (
+    ApiException,
+    ContainerContainerRemote,
+    ContainerContainerRepository,
+    ContentTagsApi,
+    RemotesContainerApi,
+    RepositoriesContainerApi,
+    RepositoriesContainerVersionsApi,
+    RepositorySyncURL,
+)
 
 
 class TestRecursiveRemove(unittest.TestCase):
@@ -26,317 +34,343 @@ class TestRecursiveRemove(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Sync pulp/test-fixture-1 so we can copy content from it."""
-        cls.cfg = config.get_config()
-        cls.client = api.Client(cls.cfg, api.json_handler)
-        cls.from_repo = cls.client.post(CONTAINER_REPO_PATH, gen_repo())
+        api_client = gen_container_client()
+        cls.repositories_api = RepositoriesContainerApi(api_client)
+        cls.remotes_api = RemotesContainerApi(api_client)
+        cls.tags_api = ContentTagsApi(api_client)
+        cls.versions_api = RepositoriesContainerVersionsApi(api_client)
+
+        cls.from_repo = cls.repositories_api.create(ContainerContainerRepository(**gen_repo()))
+
         remote_data = gen_container_remote(upstream_name=DOCKERHUB_PULP_FIXTURE_1)
-        cls.remote = cls.client.post(CONTAINER_REMOTE_PATH, remote_data)
-        sync(cls.cfg, cls.remote, cls.from_repo)
-        latest_version = cls.client.get(cls.from_repo['pulp_href'])['latest_version_href']
-        cls.latest_from_version = "repository_version={version}".format(version=latest_version)
+        cls.remote = cls.remotes_api.create(ContainerContainerRemote(**remote_data))
+
+        sync_data = RepositorySyncURL(remote=cls.remote.pulp_href)
+        sync_response = cls.repositories_api.sync(cls.from_repo.pulp_href, sync_data)
+        monitor_task(sync_response.task)
+
+        cls.latest_from_version = cls.repositories_api.read(
+            cls.from_repo.pulp_href
+        ).latest_version_href
 
     def setUp(self):
         """Create an empty repository to copy into."""
-        self.to_repo = self.client.post(CONTAINER_REPO_PATH, gen_repo())
-        self.CONTAINER_RECURSIVE_REMOVE_PATH = f'{self.to_repo["pulp_href"]}remove/'
-        self.CONTAINER_RECURSIVE_ADD_PATH = f'{self.to_repo["pulp_href"]}add/'
-        self.addCleanup(self.client.delete, self.to_repo['pulp_href'])
+        self.to_repo = self.repositories_api.create(ContainerContainerRepository(**gen_repo()))
+        self.addCleanup(self.repositories_api.delete, self.to_repo.pulp_href)
 
     @classmethod
     def tearDownClass(cls):
         """Delete things made in setUpClass. addCleanup feature does not work with setupClass."""
-        cls.client.delete(cls.from_repo['pulp_href'])
-        cls.client.delete(cls.remote['pulp_href'])
+        cls.repositories_api.delete(cls.from_repo.pulp_href)
+        cls.remotes_api.delete(cls.remote.pulp_href)
 
     def test_repository_only_no_latest_version(self):
         """Do not create a new version, when there is nothing to remove."""
-        self.client.post(self.CONTAINER_RECURSIVE_REMOVE_PATH)
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        self.assertEqual(latest_version_href, f"{self.to_repo['pulp_href']}versions/0/")
+        self.repositories_api.remove(self.to_repo.pulp_href, {})
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        self.assertEqual(latest_version_href, f"{self.to_repo.pulp_href}versions/0/")
 
     def test_remove_everything(self):
         """Add a manifest and its related blobs."""
-        manifest_a = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [manifest_a]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        manifest_a = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
         # Ensure test begins in the correct state
-        self.assertFalse('container.tag' in latest['content_summary']['added'])
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 2)
+        self.assertFalse("container.tag" in latest.content_summary.added)
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "2")
 
         # Actual test
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
-            {'content_units': ["*"]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertEqual(latest['content_summary']['present'], {})
-        self.assertEqual(latest['content_summary']['removed']['container.blob']['count'], 2)
-        self.assertEqual(latest['content_summary']['removed']['container.manifest']['count'], 1)
+        remove_response = self.repositories_api.remove(
+            self.to_repo.pulp_href,
+            {"content_units": ["*"]})
+        monitor_task(remove_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertEqual(latest.content_summary.present, {})
+        self.assertEqual(latest.content_summary.removed["container.blob"]["count"], "2")
+        self.assertEqual(latest.content_summary.removed["container.manifest"]["count"], "1")
 
     def test_remove_invalid_content_units(self):
         """Ensure exception is raised when '*' is not the only item in the content_units."""
-        with self.assertRaises(HTTPError) as context:
-            self.client.post(
-                self.CONTAINER_RECURSIVE_REMOVE_PATH,
-                {'content_units': ["*", "some_href"]}
+        with self.assertRaises(ApiException) as context:
+            self.repositories_api.remove(
+                self.to_repo.pulp_href,
+                {"content_units": ["*", "some_href"]}
             )
-        self.assertEqual(context.exception.response.status_code, 400)
+        self.assertEqual(context.exception.status, 400)
 
     def test_manifest_recursion(self):
         """Add a manifest and its related blobs."""
-        manifest_a = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [manifest_a]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        manifest_a = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
         # Ensure test begins in the correct state
-        self.assertFalse('container.tag' in latest['content_summary']['added'])
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 2)
+        self.assertFalse("container.tag" in latest.content_summary.added)
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "2")
 
         # Actual test
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
-            {'content_units': [manifest_a]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertFalse('container.tag' in latest['content_summary']['removed'])
-        self.assertEqual(latest['content_summary']['removed']['container.manifest']['count'], 1)
-        self.assertEqual(latest['content_summary']['removed']['container.blob']['count'], 2)
+        remove_response = self.repositories_api.remove(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a]})
+        monitor_task(remove_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertFalse("container.tag" in latest.content_summary.removed)
+        self.assertEqual(latest.content_summary.removed["container.manifest"]["count"], "1")
+        self.assertEqual(latest.content_summary.removed["container.blob"]["count"], "2")
 
     def test_manifest_list_recursion(self):
         """Add a Manifest List, related manifests, and related blobs."""
-        ml_i = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [ml_i]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        ml_i = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [ml_i]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
         # Ensure test begins in the correct state
-        self.assertFalse('container.tag' in latest['content_summary']['added'])
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 3)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 4)
+        self.assertFalse("container.tag" in latest.content_summary.added)
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "3")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "4")
 
         # Actual test
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
-            {'content_units': [ml_i]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertFalse('container.tag' in latest['content_summary']['removed'])
-        self.assertEqual(latest['content_summary']['removed']['container.manifest']['count'], 3)
-        self.assertEqual(latest['content_summary']['removed']['container.blob']['count'], 4)
+        remove_response = self.repositories_api.remove(
+            self.to_repo.pulp_href,
+            {"content_units": [ml_i]})
+        monitor_task(remove_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertFalse("container.tag" in latest.content_summary.removed)
+        self.assertEqual(latest.content_summary.removed["container.manifest"]["count"], "3")
+        self.assertEqual(latest.content_summary.removed["container.blob"]["count"], "4")
 
     def test_tagged_manifest_list_recursion(self):
         """Add a tagged manifest list, and its related manifests and blobs."""
-        ml_i_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [ml_i_tag]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        ml_i_tag = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [ml_i_tag]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
         # Ensure test begins in the correct state
-        self.assertEqual(latest['content_summary']['added']['container.tag']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 3)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 4)
+        self.assertEqual(latest.content_summary.added["container.tag"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "3")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "4")
 
         # Actual test
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
-            {'content_units': [ml_i_tag]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertEqual(latest['content_summary']['removed']['container.tag']['count'], 1)
-        self.assertEqual(latest['content_summary']['removed']['container.manifest']['count'], 3)
-        self.assertEqual(latest['content_summary']['removed']['container.blob']['count'], 4)
+        remove_response = self.repositories_api.remove(
+            self.to_repo.pulp_href,
+            {"content_units": [ml_i_tag]})
+        monitor_task(remove_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertEqual(latest.content_summary.removed["container.tag"]["count"], "1")
+        self.assertEqual(latest.content_summary.removed["container.manifest"]["count"], "3")
+        self.assertEqual(latest.content_summary.removed["container.blob"]["count"], "4")
 
     def test_tagged_manifest_recursion(self):
         """Add a tagged manifest and its related blobs."""
-        manifest_a_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [manifest_a_tag]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        manifest_a_tag = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a_tag]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
         # Ensure valid starting state
-        self.assertEqual(latest['content_summary']['added']['container.tag']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 2)
+        self.assertEqual(latest.content_summary.added["container.tag"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "2")
 
         # Actual test
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
-            {'content_units': [manifest_a_tag]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        remove_response = self.repositories_api.remove(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a_tag]})
+        monitor_task(remove_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
-        self.assertEqual(latest['content_summary']['removed']['container.tag']['count'], 1)
-        self.assertEqual(latest['content_summary']['removed']['container.manifest']['count'], 1)
-        self.assertEqual(latest['content_summary']['removed']['container.blob']['count'], 2)
+        self.assertEqual(latest.content_summary.removed["container.tag"]["count"], "1")
+        self.assertEqual(latest.content_summary.removed["container.manifest"]["count"], "1")
+        self.assertEqual(latest.content_summary.removed["container.blob"]["count"], "2")
 
     def test_manifests_shared_blobs(self):
         """Starting with 2 manifests that share blobs, remove one of them."""
-        manifest_a = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        manifest_e = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_e&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [manifest_a, manifest_e]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        manifest_a = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        manifest_e = self.tags_api.list(
+            name="manifest_e",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_a, manifest_e]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
         # Ensure valid starting state
-        self.assertFalse('container.tag' in latest['content_summary']['added'])
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 2)
+        self.assertFalse("container.tag" in latest.content_summary.added)
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "2")
         # manifest_a has 1 blob, 1 config blob, and manifest_e has 2 blob 1 config blob
         # manifest_a blob is shared with manifest_e
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 4)
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "4")
 
         # Actual test
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
-            {'content_units': [manifest_e]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertFalse('container.tag' in latest['content_summary']['removed'])
-        self.assertEqual(latest['content_summary']['removed']['container.manifest']['count'], 1)
+        remove_response = self.repositories_api.remove(
+            self.to_repo.pulp_href,
+            {"content_units": [manifest_e]})
+        monitor_task(remove_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertFalse("container.tag" in latest.content_summary.removed)
+        self.assertEqual(latest.content_summary.removed["container.manifest"]["count"], "1")
         # Despite having 3 blobs, only 2 are removed, 1 is shared with manifest_a.
-        self.assertEqual(latest['content_summary']['removed']['container.blob']['count'], 2)
+        self.assertEqual(latest.content_summary.removed["container.blob"]["count"], "2")
 
     def test_manifest_lists_shared_manifests(self):
         """Starting with 2 manifest lists that share a manifest, remove one of them."""
-        ml_i = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
+        ml_i = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
         # Shares 1 manifest with ml_i
-        ml_iii = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_iii&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['tagged_manifest']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
-            {'content_units': [ml_i, ml_iii]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        ml_iii = self.tags_api.list(
+            name="ml_iii",
+            repository_version=self.latest_from_version
+        ).results[0].tagged_manifest
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
+            {"content_units": [ml_i, ml_iii]})
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
         # Ensure valid starting state
-        self.assertFalse('container.tag' in latest['content_summary']['added'])
+        self.assertFalse("container.tag" in latest.content_summary.added)
         # 2 manifest lists, each with 2 manifests, 1 manifest shared
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 5)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 6)
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "5")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "6")
 
         # Actual test
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
-            {'content_units': [ml_iii]})
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertFalse('container.tag' in latest['content_summary']['removed'])
+        remove_response = self.repositories_api.remove(
+            self.to_repo.pulp_href,
+            {"content_units": [ml_iii]})
+        monitor_task(remove_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertFalse("container.tag" in latest.content_summary.removed)
         # 1 manifest list, 1 manifest
-        self.assertEqual(latest['content_summary']['removed']['container.manifest']['count'], 2)
-        self.assertEqual(latest['content_summary']['removed']['container.blob']['count'], 2)
+        self.assertEqual(latest.content_summary.removed["container.manifest"]["count"], "2")
+        self.assertEqual(latest.content_summary.removed["container.blob"]["count"], "2")
 
     def test_many_tagged_manifest_lists(self):
         """Add several Manifest List, related manifests, and related blobs."""
-        ml_i_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_i&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        ml_ii_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_ii&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        ml_iii_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_iii&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        ml_iv_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=ml_iv&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]['pulp_href']
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
+        ml_i_tag = self.tags_api.list(
+            name="ml_i",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        ml_ii_tag = self.tags_api.list(
+            name="ml_ii",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        ml_iii_tag = self.tags_api.list(
+            name="ml_iii",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        ml_iv_tag = self.tags_api.list(
+            name="ml_iv",
+            repository_version=self.latest_from_version
+        ).results[0].pulp_href
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
             {
-                'content_units': [ml_i_tag, ml_ii_tag, ml_iii_tag, ml_iv_tag]
+                "content_units": [ml_i_tag, ml_ii_tag, ml_iii_tag, ml_iv_tag]
             }
         )
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
-        self.assertEqual(latest['content_summary']['added']['container.tag']['count'], 4)
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 9)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 10)
+        self.assertEqual(latest.content_summary.added["container.tag"]["count"], "4")
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "9")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "10")
 
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
+        remove_response = self.repositories_api.remove(
+            self.to_repo.pulp_href,
             {
-                'content_units': [ml_i_tag, ml_ii_tag, ml_iii_tag, ml_iv_tag]
+                "content_units": [ml_i_tag, ml_ii_tag, ml_iii_tag, ml_iv_tag]
             }
         )
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
+        monitor_task(remove_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
 
-        self.assertEqual(latest['content_summary']['removed']['container.tag']['count'], 4)
-        self.assertEqual(latest['content_summary']['removed']['container.manifest']['count'], 9)
-        self.assertEqual(latest['content_summary']['removed']['container.blob']['count'], 10)
+        self.assertEqual(latest.content_summary.removed["container.tag"]["count"], "4")
+        self.assertEqual(latest.content_summary.removed["container.manifest"]["count"], "9")
+        self.assertEqual(latest.content_summary.removed["container.blob"]["count"], "10")
 
     def test_cannot_remove_tagged_manifest(self):
         """
         Try to remove a manifest (without removing tag). Creates a new version, but nothing removed.
         """
-        manifest_a_tag = self.client.get("{unit_path}?{filters}".format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters="name=manifest_a&{v_filter}".format(v_filter=self.latest_from_version),
-        ))['results'][0]
-        self.client.post(
-            self.CONTAINER_RECURSIVE_ADD_PATH,
+        manifest_a_tag = self.tags_api.list(
+            name="manifest_a",
+            repository_version=self.latest_from_version
+        ).results[0]
+        add_response = self.repositories_api.add(
+            self.to_repo.pulp_href,
             {
-                'content_units': [manifest_a_tag['pulp_href']]
+                "content_units": [manifest_a_tag.pulp_href]
             }
         )
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        self.assertEqual(latest['content_summary']['added']['container.tag']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.manifest']['count'], 1)
-        self.assertEqual(latest['content_summary']['added']['container.blob']['count'], 2)
+        monitor_task(add_response.task)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        self.assertEqual(latest.content_summary.added["container.tag"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.manifest"]["count"], "1")
+        self.assertEqual(latest.content_summary.added["container.blob"]["count"], "2")
 
-        self.client.post(
-            self.CONTAINER_RECURSIVE_REMOVE_PATH,
+        remove_respone = self.repositories_api.remove(
+            self.to_repo.pulp_href,
             {
-                'content_units': [manifest_a_tag['tagged_manifest']]
+                "content_units": [manifest_a_tag.tagged_manifest]
             }
         )
+        monitor_task(remove_respone.task)
 
-        latest_version_href = self.client.get(self.to_repo['pulp_href'])['latest_version_href']
-        latest = self.client.get(latest_version_href)
-        for content_type in ['container.tag', 'container.manifest', 'container.blob']:
-            self.assertFalse(content_type in latest['content_summary']['removed'], msg=content_type)
+        latest_version_href = self.repositories_api.read(self.to_repo.pulp_href).latest_version_href
+        latest = self.versions_api.read(latest_version_href)
+        for content_type in ["container.tag", "container.manifest", "container.blob"]:
+            self.assertFalse(content_type in latest.content_summary.removed, msg=content_type)

--- a/pulp_container/tests/functional/api/test_repositories_list.py
+++ b/pulp_container/tests/functional/api/test_repositories_list.py
@@ -5,17 +5,27 @@ import unittest
 from urllib.parse import urljoin
 from requests.exceptions import HTTPError
 
-from pulp_smash import api, config, cli
-from pulp_smash.pulp3.utils import gen_repo, sync, gen_distribution
+from pulp_smash import api, config
+from pulp_smash.pulp3.utils import gen_distribution, gen_repo
 
-from pulp_container.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
-from pulp_container.tests.functional.utils import gen_container_remote, BearerTokenAuth
+from pulp_container.tests.functional.constants import DOCKERHUB_PULP_FIXTURE_1
 
-from pulp_container.tests.functional.constants import (
-    CONTAINER_DISTRIBUTION_PATH,
-    CONTAINER_REMOTE_PATH,
-    CONTAINER_REPO_PATH,
-    DOCKERHUB_PULP_FIXTURE_1,
+from pulp_container.tests.functional.utils import (
+    gen_container_remote,
+    gen_container_client,
+    gen_token_signing_keys,
+    monitor_task,
+    BearerTokenAuth,
+)
+
+from pulpcore.client.pulp_container import (
+    ContainerContainerRepository,
+    ContainerContainerDistribution,
+    ContainerContainerRemote,
+    DistributionsContainerApi,
+    RepositoriesContainerApi,
+    RemotesContainerApi,
+    RepositorySyncURL,
 )
 
 
@@ -25,38 +35,46 @@ class RepositoriesListTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create class wide-variables."""
+        api_client = gen_container_client()
+        cls.repositories_api = RepositoriesContainerApi(api_client)
+        cls.remotes_api = RemotesContainerApi(api_client)
+        cls.distributions_api = DistributionsContainerApi(api_client)
+
         cls.cfg = config.get_config()
+        gen_token_signing_keys(cls.cfg)
         cls.client = api.Client(cls.cfg, api.json_handler)
 
-        token_auth = cls.cfg.hosts[0].roles['token auth']
-        client = cli.Client(cls.cfg)
-        client.run('openssl ecparam -genkey -name prime256v1 -noout -out {}'
-                   .format(token_auth['private key']).split())
-        client.run('openssl ec -in {} -pubout -out {}'.format(
-            token_auth['private key'], token_auth['public key']).split())
+        cls.repository = cls.repositories_api.create(ContainerContainerRepository(**gen_repo()))
 
-        cls.repository = cls.client.post(CONTAINER_REPO_PATH, gen_repo())
         remote_data = gen_container_remote(upstream_name=DOCKERHUB_PULP_FIXTURE_1)
-        cls.remote = cls.client.post(CONTAINER_REMOTE_PATH, remote_data)
-        sync(cls.cfg, cls.remote, cls.repository)
+        cls.remote = cls.remotes_api.create(ContainerContainerRemote(**remote_data))
 
-        cls.distribution1 = cls.client.using_handler(api.task_handler).post(
-            CONTAINER_DISTRIBUTION_PATH,
-            gen_distribution(repository=cls.repository['pulp_href'])
+        sync_data = RepositorySyncURL(remote=cls.remote.pulp_href)
+        sync_response = cls.repositories_api.sync(cls.repository.pulp_href, sync_data)
+        monitor_task(sync_response.task)
+
+        distribution_data = gen_distribution(repository=cls.repository.pulp_href)
+        distribution_response = cls.distributions_api.create(
+            ContainerContainerDistribution(**distribution_data)
         )
-        cls.distribution2 = cls.client.using_handler(api.task_handler).post(
-            CONTAINER_DISTRIBUTION_PATH,
-            gen_distribution(repository=cls.repository['pulp_href'])
+        created_resources = monitor_task(distribution_response.task)
+        cls.distribution1 = cls.distributions_api.read(created_resources[0])
+
+        distribution_data = gen_distribution(repository=cls.repository.pulp_href)
+        distribution_response = cls.distributions_api.create(
+            ContainerContainerDistribution(**distribution_data)
         )
+        created_resources = monitor_task(distribution_response.task)
+        cls.distribution2 = cls.distributions_api.read(created_resources[0])
 
     @classmethod
     def tearDownClass(cls):
         """Clean generated resources."""
-        cls.client.delete(cls.repository['pulp_href'])
-        cls.client.delete(cls.remote['pulp_href'])
+        cls.repositories_api.delete(cls.repository.pulp_href)
+        cls.remotes_api.delete(cls.remote.pulp_href)
 
-        cls.client.delete(cls.distribution1['pulp_href'])
-        cls.client.delete(cls.distribution2['pulp_href'])
+        cls.distributions_api.delete(cls.distribution1.pulp_href)
+        cls.distributions_api.delete(cls.distribution2.pulp_href)
 
     def test_listing_repositories(self):
         """
@@ -66,22 +84,22 @@ class RepositoriesListTestCase(unittest.TestCase):
         caught an exception for the HTTP 401 response at first. Then, the token is retrieved
         from the token server and is used for requesting the list of repositories again.
         """
-        repositories_list_endpoint = urljoin(self.cfg.get_content_host_base_url(), '/v2/_catalog')
+        repositories_list_endpoint = urljoin(self.cfg.get_content_host_base_url(), "/v2/_catalog")
 
         with self.assertRaises(HTTPError) as cm:
             self.client.get(repositories_list_endpoint)
         content_response = cm.exception.response
-        authenticate_header = content_response.headers['Www-Authenticate']
+        authenticate_header = content_response.headers["Www-Authenticate"]
 
         queries = AuthenticationHeaderQueries(authenticate_header)
-        content_response = self.client.get(queries.realm, params={'service': queries.service})
+        content_response = self.client.get(queries.realm, params={"service": queries.service})
         repositories = self.client.get(
             repositories_list_endpoint,
-            auth=BearerTokenAuth(content_response['token'])
+            auth=BearerTokenAuth(content_response["token"])
         )
 
-        repositories_names = [self.distribution1['base_path'], self.distribution2['base_path']]
-        self.assertEqual(repositories, {'repositories': repositories_names})
+        repositories_names = [self.distribution1.base_path, self.distribution2.base_path]
+        self.assertEqual(repositories, {"repositories": repositories_names})
 
 
 class AuthenticationHeaderQueries:

--- a/pulp_container/tests/functional/api/test_tagging_images.py
+++ b/pulp_container/tests/functional/api/test_tagging_images.py
@@ -2,19 +2,31 @@
 """Tests for tagging and untagging images."""
 import unittest
 
-from pulp_smash import api, config
-from pulp_smash.pulp3.utils import gen_repo, sync
+from pulp_smash.pulp3.utils import gen_repo
 
-from pulp_container.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
-from pulp_container.tests.functional.utils import gen_container_remote
-
+from pulp_container.tests.functional.utils import (
+    gen_container_remote,
+    gen_container_client,
+    monitor_task,
+)
 from pulp_container.tests.functional.constants import (
     CONTAINER_TAG_PATH,
-    CONTAINER_REMOTE_PATH,
-    CONTAINER_REPO_PATH,
     DOCKERHUB_PULP_FIXTURE_1,
 )
-from requests import HTTPError
+
+from pulpcore.client.pulp_container import (
+    ApiException,
+    ContainerContainerRemote,
+    ContainerContainerRepository,
+    ContentManifestsApi,
+    ContentTagsApi,
+    RepositoriesContainerApi,
+    RepositoriesContainerVersionsApi,
+    RepositorySyncURL,
+    RemotesContainerApi,
+    TagImage,
+    UnTagImage,
+)
 
 
 class TaggingTestCase(unittest.TestCase):
@@ -23,19 +35,27 @@ class TaggingTestCase(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         """Create class wide-variables."""
-        cls.cfg = config.get_config()
-        cls.client = api.Client(cls.cfg, api.json_handler)
+        api_client = gen_container_client()
+        cls.repositories_api = RepositoriesContainerApi(api_client)
+        cls.versions_api = RepositoriesContainerVersionsApi(api_client)
+        cls.remotes_api = RemotesContainerApi(api_client)
+        cls.tags_api = ContentTagsApi(api_client)
+        cls.manifests_api = ContentManifestsApi(api_client)
 
-        cls.repository = cls.client.post(CONTAINER_REPO_PATH, gen_repo())
+        cls.repository = cls.repositories_api.create(ContainerContainerRepository(**gen_repo()))
+
         remote_data = gen_container_remote(upstream_name=DOCKERHUB_PULP_FIXTURE_1)
-        cls.remote = cls.client.post(CONTAINER_REMOTE_PATH, remote_data)
-        sync(cls.cfg, cls.remote, cls.repository)
+        cls.remote = cls.remotes_api.create(ContainerContainerRemote(**remote_data))
+
+        sync_data = RepositorySyncURL(remote=cls.remote.pulp_href)
+        sync_response = cls.repositories_api.sync(cls.repository.pulp_href, sync_data)
+        monitor_task(sync_response.task)
 
     @classmethod
     def tearDownClass(cls):
         """Clean generated resources."""
-        cls.client.delete(cls.repository['pulp_href'])
-        cls.client.delete(cls.remote['pulp_href'])
+        cls.repositories_api.delete(cls.repository.pulp_href)
+        cls.remotes_api.delete(cls.remote.pulp_href)
 
     def test_01_tag_first_image(self):
         """
@@ -43,28 +63,25 @@ class TaggingTestCase(unittest.TestCase):
 
         This test checks if the tag was created in a new repository version.
         """
-        manifest_a = self.get_manifest_by_tag('manifest_a')
-        self.tag_image(manifest_a, 'new_tag')
+        manifest_a = self.get_manifest_by_tag("manifest_a")
+        self.tag_image(manifest_a, "new_tag")
 
-        new_repository_version_href = '{repository_href}versions/{new_version}/'.format(
-            repository_href=self.repository['pulp_href'],
+        new_repository_version_href = "{repository_href}versions/{new_version}/".format(
+            repository_href=self.repository.pulp_href,
             new_version='2'
         )
+        created_tag = self.tags_api.list(
+            repository_version_added=new_repository_version_href
+        ).results[0]
+        self.assertEqual(created_tag.name, "new_tag", created_tag.name)
 
-        added_tags_href = '{unit_path}?{filters}'.format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters=f'repository_version_added={new_repository_version_href}'
-        )
-        created_tag = self.client.get(added_tags_href)['results'][0]
-        self.assertEqual(created_tag['name'], 'new_tag', created_tag['name'])
+        repository_version = self.versions_api.read(new_repository_version_href)
 
-        repository_version = self.client.get(new_repository_version_href)
+        added_content = repository_version.content_summary.added
+        added_tags = added_content["container.tag"]["count"]
+        self.assertEqual(added_tags, "1", added_content)
 
-        added_content = repository_version['content_summary']['added']
-        added_tags = added_content['container.tag']['count']
-        self.assertEqual(added_tags, 1, added_content)
-
-        removed_content = repository_version['content_summary']['removed']
+        removed_content = repository_version.content_summary.removed
         self.assertEqual(removed_content, {}, removed_content)
 
     def test_02_tag_first_image_with_same_tag(self):
@@ -73,18 +90,18 @@ class TaggingTestCase(unittest.TestCase):
 
         This test checks if a new repository version was created with no content added.
         """
-        latest_version_before = self.client.get(
-            self.repository['pulp_href']
-        )['latest_version_href']
+        latest_version_before = self.repositories_api.read(
+            self.repository.pulp_href
+        ).latest_version_href
 
-        manifest_a = self.get_manifest_by_tag('manifest_a')
-        self.tag_image(manifest_a, 'new_tag')
+        manifest_a = self.get_manifest_by_tag("manifest_a")
+        self.tag_image(manifest_a, "new_tag")
 
-        latest_version_after = self.client.get(
-            self.repository['pulp_href']
-        )['latest_version_href']
+        latest_version_after = self.repositories_api.read(
+            self.repository.pulp_href
+        ).latest_version_href
 
-        self.assertEquals(latest_version_before, latest_version_after)
+        self.assertEqual(latest_version_before, latest_version_after)
 
     def test_03_tag_second_image_with_same_tag(self):
         """
@@ -93,99 +110,93 @@ class TaggingTestCase(unittest.TestCase):
         This test checks if a new repository version was created with a new content added
         and the old removed.
         """
-        manifest_a = self.get_manifest_by_tag('manifest_a')
-        manifest_b = self.get_manifest_by_tag('manifest_b')
-        self.tag_image(manifest_b, 'new_tag')
+        manifest_a = self.get_manifest_by_tag("manifest_a")
+        manifest_b = self.get_manifest_by_tag("manifest_b")
+        self.tag_image(manifest_b, "new_tag")
 
-        new_repository_version_href = '{repository_href}versions/{new_version}/'.format(
-            repository_href=self.repository['pulp_href'],
-            new_version='3'
+        new_repository_version_href = "{repository_href}versions/{new_version}/".format(
+            repository_href=self.repository.pulp_href,
+            new_version="3"
         )
+        created_tag = self.tags_api.list(
+            repository_version_added=new_repository_version_href
+        ).results[0]
+        self.assertEqual(created_tag.name, "new_tag", created_tag.name)
 
-        added_tags_href = '{unit_path}?{filters}'.format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters=f'repository_version_added={new_repository_version_href}'
-        )
-        created_tag = self.client.get(added_tags_href)['results'][0]
-        self.assertEqual(created_tag['name'], 'new_tag', created_tag['name'])
-
-        created_tag_manifest = self.client.get(created_tag['tagged_manifest'])
+        created_tag_manifest = self.manifests_api.read(created_tag.tagged_manifest)
         self.assertEqual(created_tag_manifest, manifest_b, created_tag_manifest)
 
-        removed_tags_href = '{unit_path}?{filters}'.format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters=f'repository_version_removed={new_repository_version_href}'
-        )
-        removed_tag = self.client.get(removed_tags_href)['results'][0]
-        self.assertEqual(removed_tag['name'], 'new_tag', removed_tag['name'])
+        removed_tag = self.tags_api.list(
+            repository_version_removed=new_repository_version_href
+        ).results[0]
+        self.assertEqual(removed_tag.name, "new_tag", removed_tag.name)
 
-        removed_tag_manifest = self.client.get(removed_tag['tagged_manifest'])
+        removed_tag_manifest = self.manifests_api.read(removed_tag.tagged_manifest)
         self.assertEqual(removed_tag_manifest, manifest_a, removed_tag_manifest)
 
-        repository_version = self.client.get(new_repository_version_href)
+        repository_version = self.versions_api.read(new_repository_version_href)
 
-        added_content = repository_version['content_summary']['added']
-        added_tags = added_content['container.tag']['count']
-        self.assertEqual(added_tags, 1, added_content)
+        added_content = repository_version.content_summary.added
+        added_tags = added_content["container.tag"]["count"]
+        self.assertEqual(added_tags, "1", added_content)
 
-        removed_content = repository_version['content_summary']['removed']
-        removed_tags = removed_content['container.tag']['count']
-        self.assertEqual(removed_tags, 1, removed_content)
+        removed_content = repository_version.content_summary.removed
+        removed_tags = removed_content["container.tag"]["count"]
+        self.assertEqual(removed_tags, "1", removed_content)
 
     def test_04_untag_second_image(self):
         """Untag the manifest and check if the tag was added in a new repository version."""
-        self.untag_image('new_tag')
+        self.untag_image("new_tag")
 
-        new_repository_version_href = '{repository_href}versions/{new_version}/'.format(
-            repository_href=self.repository['pulp_href'],
-            new_version='4'
+        new_repository_version_href = "{repository_href}versions/{new_version}/".format(
+            repository_href=self.repository.pulp_href,
+            new_version="4"
         )
 
-        removed_tags_href = '{unit_path}?{filters}'.format(
+        removed_tags_href = "{unit_path}?{filters}".format(
             unit_path=CONTAINER_TAG_PATH,
-            filters=f'repository_version_removed={new_repository_version_href}'
+            filters=f"repository_version_removed={new_repository_version_href}"
         )
 
-        repository_version = self.client.get(new_repository_version_href)
+        repository_version = self.versions_api.read(new_repository_version_href)
 
-        removed_content = repository_version['content_summary']['removed']
-        removed_tags = removed_content['container.tag']['href']
+        removed_content = repository_version.content_summary.removed
+        removed_tags = removed_content["container.tag"]["href"]
         self.assertEqual(removed_tags, removed_tags_href, removed_tags)
 
-        added_content = repository_version['content_summary']['added']
+        added_content = repository_version.content_summary.added
         self.assertEqual(added_content, {}, added_content)
 
-        removed_tag = self.client.get(removed_tags_href)['results'][0]
-        self.assertEqual(removed_tag['name'], 'new_tag', removed_tag)
+        removed_tag = self.tags_api.list(
+            repository_version_removed=new_repository_version_href
+        ).results[0]
+        self.assertEqual(removed_tag.name, "new_tag", removed_tag)
 
     def test_05_untag_second_image_again(self):
         """Untag the manifest that was already untagged."""
-        with self.assertRaises(HTTPError):
-            self.untag_image('new_tag')
+        with self.assertRaises(ApiException):
+            self.untag_image("new_tag")
 
     def get_manifest_by_tag(self, tag_name):
         """Fetch a manifest by the tag name."""
-        latest_version = self.client.get(
-            self.repository['pulp_href']
-        )['latest_version_href']
+        latest_version_href = self.repositories_api.read(
+            self.repository.pulp_href
+        ).latest_version_href
 
-        manifest_a_href = self.client.get('{unit_path}?{filters}'.format(
-            unit_path=CONTAINER_TAG_PATH,
-            filters=f'name={tag_name}&repository_version={latest_version}'
-        ))['results'][0]['tagged_manifest']
-        return self.client.get(manifest_a_href)
+        manifest_a_href = self.tags_api.list(
+            name=tag_name,
+            repository_version=latest_version_href
+        ).results[0].tagged_manifest
+        return self.manifests_api.read(manifest_a_href)
 
     def tag_image(self, manifest, tag_name):
         """Perform a tagging operation."""
-        params = {
-            'tag': tag_name,
-            'digest': manifest['digest']
-        }
-        self.client.post(f'{self.repository["pulp_href"]}tag/', params)
+        tag_data = TagImage(tag=tag_name, digest=manifest.digest)
+        tag_response = self.repositories_api.tag(self.repository.pulp_href, tag_data)
+        monitor_task(tag_response.task)
 
     def untag_image(self, tag_name):
         """Perform an untagging operation."""
-        params = {
-            'tag': tag_name,
-        }
-        self.client.post(f'{self.repository["pulp_href"]}untag/', params)
+        untag_data = UnTagImage(tag=tag_name)
+        untag_response = self.repositories_api.untag(self.repository.pulp_href, untag_data)
+        monitor_task(untag_response.task)

--- a/pulp_container/tests/functional/api/test_token_authentication.py
+++ b/pulp_container/tests/functional/api/test_token_authentication.py
@@ -6,30 +6,30 @@ from urllib.parse import urljoin
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, cli
-from pulp_smash.pulp3.utils import gen_repo, sync, gen_distribution
+from pulp_smash.pulp3.utils import gen_repo, gen_distribution
 
-from pulp_container.tests.functional.utils import set_up_module as setUpModule  # noqa:F401
-from pulp_container.tests.functional.utils import gen_container_remote, BearerTokenAuth
-
+from pulp_container.tests.functional.utils import (
+    gen_container_remote,
+    gen_container_client,
+    gen_token_signing_keys,
+    monitor_task,
+    BearerTokenAuth,
+)
 from pulp_container.tests.functional.constants import (
     CONTAINER_TAG_PATH,
-    CONTAINER_REMOTE_PATH,
-    CONTAINER_REPO_PATH,
-    CONTAINER_DISTRIBUTION_PATH,
     DOCKERHUB_PULP_FIXTURE_1,
 )
 from pulp_container.constants import MEDIA_TYPE
 
-
-"""
-@unittest.skip(
-    "A handler for a token authentication relies on a provided token server's "
-    "fully qualified domain name (TOKEN_SERVER) in the file /etc/pulp/settings.py; "
-    "therefore, it is necessary to check if TOKEN_SERVER was specified; otherwise, "
-    "these tests are no longer valid because the token authentication is turned off "
-    "by default."
+from pulpcore.client.pulp_container import (
+    ContainerContainerDistribution,
+    ContainerContainerRepository,
+    ContainerContainerRemote,
+    DistributionsContainerApi,
+    RepositoriesContainerApi,
+    RemotesContainerApi,
+    RepositorySyncURL,
 )
-"""
 
 
 class TokenAuthenticationTestCase(unittest.TestCase):
@@ -45,32 +45,36 @@ class TokenAuthenticationTestCase(unittest.TestCase):
     def setUpClass(cls):
         """Create class wide-variables."""
         cls.cfg = config.get_config()
-
-        token_auth = cls.cfg.hosts[0].roles['token auth']
-        client = cli.Client(cls.cfg)
-        client.run('openssl ecparam -genkey -name prime256v1 -noout -out {}'
-                   .format(token_auth['private key']).split())
-        client.run('openssl ec -in {} -pubout -out {}'.format(
-            token_auth['private key'], token_auth['public key']).split())
-
+        gen_token_signing_keys(cls.cfg)
         cls.client = api.Client(cls.cfg, api.page_handler)
 
-        cls.repository = cls.client.post(CONTAINER_REPO_PATH, gen_repo())
-        remote_data = gen_container_remote(upstream_name=DOCKERHUB_PULP_FIXTURE_1)
-        cls.remote = cls.client.post(CONTAINER_REMOTE_PATH, remote_data)
-        sync(cls.cfg, cls.remote, cls.repository)
+        api_client = gen_container_client()
+        cls.repositories_api = RepositoriesContainerApi(api_client)
+        cls.remotes_api = RemotesContainerApi(api_client)
+        cls.distributions_api = DistributionsContainerApi(api_client)
 
-        cls.distribution = cls.client.using_handler(api.task_handler).post(
-            CONTAINER_DISTRIBUTION_PATH,
-            gen_distribution(repository=cls.repository['pulp_href'])
+        cls.repository = cls.repositories_api.create(ContainerContainerRepository(**gen_repo()))
+
+        remote_data = gen_container_remote(upstream_name=DOCKERHUB_PULP_FIXTURE_1)
+        cls.remote = cls.remotes_api.create(ContainerContainerRemote(**remote_data))
+
+        sync_data = RepositorySyncURL(remote=cls.remote.pulp_href)
+        sync_response = cls.repositories_api.sync(cls.repository.pulp_href, sync_data)
+        monitor_task(sync_response.task)
+
+        distribution_data = gen_distribution(repository=cls.repository.pulp_href)
+        distribution_response = cls.distributions_api.create(
+            ContainerContainerDistribution(**distribution_data)
         )
+        created_resources = monitor_task(distribution_response.task)
+        cls.distribution = cls.distributions_api.read(created_resources[0])
 
     @classmethod
     def tearDownClass(cls):
         """Clean generated resources."""
-        cls.client.delete(cls.repository['pulp_href'])
-        cls.client.delete(cls.remote['pulp_href'])
-        cls.client.delete(cls.distribution['pulp_href'])
+        cls.repositories_api.delete(cls.repository.pulp_href)
+        cls.remotes_api.delete(cls.remote.pulp_href)
+        cls.distributions_api.delete(cls.distribution.pulp_href)
 
     def test_pull_image_with_raw_http_requests(self):
         """
@@ -80,27 +84,27 @@ class TokenAuthenticationTestCase(unittest.TestCase):
         Bearer token. The generated Bearer token is afterwards used to pull the image.
         All requests are sent via aiohttp modules.
         """
-        image_path = '/v2/{}/manifests/{}'.format(self.distribution['base_path'], 'manifest_a')
+        image_path = "/v2/{}/manifests/{}".format(self.distribution.base_path, "manifest_a")
         latest_image_url = urljoin(self.cfg.get_content_host_base_url(), image_path)
 
         with self.assertRaises(HTTPError) as cm:
-            self.client.get(latest_image_url, headers={'Accept': MEDIA_TYPE.MANIFEST_V2})
+            self.client.get(latest_image_url, headers={"Accept": MEDIA_TYPE.MANIFEST_V2})
 
         content_response = cm.exception.response
         self.assertEqual(content_response.status_code, 401)
 
-        authenticate_header = content_response.headers['Www-Authenticate']
+        authenticate_header = content_response.headers["Www-Authenticate"]
         queries = AuthenticationHeaderQueries(authenticate_header)
         content_response = self.client.get(
             queries.realm,
-            params={'service': queries.service, 'scope': queries.scope}
+            params={"service": queries.service, "scope": queries.scope}
         )
         content_response = self.client.get(
             latest_image_url,
-            auth=BearerTokenAuth(content_response['token']),
-            headers={'Accept': MEDIA_TYPE.MANIFEST_V2}
+            auth=BearerTokenAuth(content_response["token"]),
+            headers={"Accept": MEDIA_TYPE.MANIFEST_V2}
         )
-        self.compare_config_blob_digests(content_response['config']['digest'])
+        self.compare_config_blob_digests(content_response["config"]["digest"])
 
     def test_pull_image_with_real_container_client(self):
         """
@@ -110,13 +114,13 @@ class TokenAuthenticationTestCase(unittest.TestCase):
         image from a secured registry.
         """
         registry = cli.RegistryClient(self.cfg)
-        registry.raise_if_unsupported(unittest.SkipTest, 'Test requires podman/docker')
+        registry.raise_if_unsupported(unittest.SkipTest, "Test requires podman/docker")
 
         image_url = urljoin(
             self.cfg.get_content_host_base_url(),
-            self.distribution['base_path']
+            self.distribution.base_path
         )
-        image_with_tag = f'{image_url}:manifest_a'
+        image_with_tag = f"{image_url}:manifest_a"
         registry.pull(image_with_tag)
 
         image = registry.inspect(image_with_tag)
@@ -126,19 +130,24 @@ class TokenAuthenticationTestCase(unittest.TestCase):
         # 'Id': 'd21d863f69b5de1a973a41344488f2ec89a625f2624195f51b4e2d54a97fc53b' (podman)
         # As long as the output differs in this manner, it is necessary to prepend the string
         # 'sha256:' to the fetched digest.
-        image_digest = 'sha256:' + image[0]['Id'].lstrip('sha256:')
+        image_id = image[0]["Id"]
+        if image_id.startswith("sha256:"):
+            image_digest = image_id
+        else:
+            image_digest = "sha256:" + image_id
+
         self.compare_config_blob_digests(image_digest)
 
     def compare_config_blob_digests(self, pulled_manifest_digest):
         """Check if a valid config was pulled from a registry."""
-        tags_by_name_url = f'{CONTAINER_TAG_PATH}?name=manifest_a'
+        tags_by_name_url = f"{CONTAINER_TAG_PATH}?name=manifest_a"
         tag_response = self.client.get(tags_by_name_url)
 
-        tagged_manifest_href = tag_response[0]['tagged_manifest']
+        tagged_manifest_href = tag_response[0]["tagged_manifest"]
         manifest_response = self.client.get(tagged_manifest_href)
 
-        config_blob_response = self.client.get(manifest_response['config_blob'])
-        self.assertEqual(pulled_manifest_digest, config_blob_response['digest'])
+        config_blob_response = self.client.get(manifest_response["config_blob"])
+        self.assertEqual(pulled_manifest_digest, config_blob_response["digest"])
 
 
 class AuthenticationHeaderQueries:
@@ -146,7 +155,7 @@ class AuthenticationHeaderQueries:
 
     def __init__(self, authenticate_header):
         """Extract service, realm, and scope from the header."""
-        realm, service, scope = authenticate_header[7:].split(',')
+        realm, service, scope = authenticate_header[7:].split(",")
         # realm="rlm" -> rlm
         self.realm = realm[6:][1:-1]
         # service="srv" -> srv

--- a/pulp_container/tests/functional/constants.py
+++ b/pulp_container/tests/functional/constants.py
@@ -15,8 +15,6 @@ CONTAINER_TAG_PATH = urljoin(BASE_CONTENT_PATH, 'container/tags/')
 
 CONTAINER_BLOB_PATH = urljoin(BASE_CONTENT_PATH, 'container/blobs/')
 
-CONTAINER_CONTENT_PATH = urljoin(BASE_CONTENT_PATH, 'container/unit/')
-
 CONTAINER_CONTENT_NAME = 'container.blob'
 
 CONTAINER_DISTRIBUTION_PATH = urljoin(BASE_DISTRIBUTION_PATH, 'container/container/')

--- a/pulp_container/tests/unit/test_convert.py
+++ b/pulp_container/tests/unit/test_convert.py
@@ -1,11 +1,13 @@
 import base64
 
+from django.test import TestCase
+
 from jwkest import jws
 
 from pulp_container.app import schema_convert
 
 
-class Test:
+class Test(TestCase):
     """Schema2toSchema1Converter test class"""
 
     def test_convert(self):

--- a/unittest_requirements.txt
+++ b/unittest_requirements.txt
@@ -1,1 +1,4 @@
+ecdsa~=0.13.2
 mock
+pulpcore>=3.0rc8,<3.2
+pyjwkest~=1.4.0


### PR DESCRIPTION
In addition, the test test_convert.py was moved to the directory tests/unit/.

closes #6069
https://pulp.plan.io/issues/6069