### PR TITLE
Removes sudo from the buildah command

### DIFF
--- a/CHANGES/5895.bugfix
+++ b/CHANGES/5895.bugfix
@@ -1,0 +1,1 @@
+Building an image from a Containerfile no longer requires root access.

--- a/docs/_scripts/create_containerfile.sh
+++ b/docs/_scripts/create_containerfile.sh
@@ -4,10 +4,7 @@ echo "Create a Containerfile that expects foo/bar/example.txt inside /pulp_worki
 
 echo 'FROM centos:7
 
-# Copy a file using RUN statement (absolute path required)
-RUN cp /pulp_working_directory/foo/bar/example.txt /
-
-# Copy a file using COPY statement (relative path can be used)
+# Copy a file using COPY statement. Use the relative path specified in the 'artifacts' parameter.
 COPY foo/bar/example.txt /inside-image.txt
 
 # Print the content of the file when the container starts

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -73,8 +73,12 @@ Enable OCI Container Image building
 -----------------------------------
 
 Pulp container plugin can be used to build an OCI format image from a Containerfile. The plugin uses
-`buildah <https://github.com/containers/buildah/>`_ to build the container image. Buildah 1.11+
+`buildah <https://github.com/containers/buildah/>`_ to build the container image. Buildah 1.14+
 must be installed on the same machine that is running pulpcore-worker processes.
 
-The systemd unit file for pulpcore-worker processes needs to add `/usr/bin/` to the `PATH`.
-The user which pulpcore-worker runs as needs to be able to sudo without a password.
+The pulpcore-worker processes needs to have `/usr/bin/` in its `PATH`. The user that is running
+pulpcore-worker process needs to be able to manage subordinate user ids and group ids. The range of
+subordinate user ids is specified in `/etc/subuid` and the range of subordinate group ids is
+specified in `/etc/subgid`. More details can be found in `buildah documentation <https://github.com
+/containers/libpod/blob/master/docs/tutorials/rootless_tutorial.md#enable-user-namespaces-on-rhel7-
+machines>`_.

--- a/pulp_container/app/tasks/builder.py
+++ b/pulp_container/app/tasks/builder.py
@@ -118,15 +118,13 @@ def build_image_from_containerfile(containerfile_pk=None, artifacts={}, reposito
                 os.makedirs(dirs)
 
             shutil.copy(artifact.file.path, "{}{}".format(path, val))
-        bud_cp = subprocess.run(["sudo", "buildah", "bud", "-v",
-                                 "{}:/pulp_working_directory".format(path), "-f",
-                                 containerfile.file.path, "-t", name], stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE)
+        bud_cp = subprocess.run(["buildah", "bud", "-f", containerfile.file.path, "-t", name],
+                                stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if bud_cp.returncode != 0:
             raise Exception(bud_cp.stderr)
         image_dir = '{}image/'.format(path)
         os.makedirs(image_dir)
-        push_cp = subprocess.run(["sudo", "buildah", "push", "-f", "oci", name,
+        push_cp = subprocess.run(["buildah", "push", "-f", "oci", name,
                                   "dir:{}".format(image_dir)],
                                  stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         if push_cp.returncode != 0:


### PR DESCRIPTION
This patch also removes the use of a volume mount. There seems to be a problem with using a
volume mount when running buildah inside a container.

fixes: #5895
https://pulp.plan.io/issues/5895