### PR TITLE
1.2.0 changelog and version bumps

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,35 @@ Changelog
 
 .. towncrier release notes start
 
+1.2.0 (2020-03-05)
+==================
+
+
+Features
+--------
+
+- Enable users to sync content in mirror mode
+  `#5771 <https://pulp.plan.io/issues/5771>`_
+- Provide apache and nginx config snippets to be used by the installer.
+  `#6292 <https://pulp.plan.io/issues/6292>`_
+
+
+Bugfixes
+--------
+
+- Building an image from a Containerfile no longer requires root access.
+  `#5895 <https://pulp.plan.io/issues/5895>`_
+
+
+Misc
+----
+
+- `#6069 <https://pulp.plan.io/issues/6069>`_
+
+
+----
+
+
 1.1.0 (2020-01-22)
 ==================
 

--- a/CHANGES/5771.feature
+++ b/CHANGES/5771.feature
@@ -1,1 +1,0 @@
-Enable users to sync content in mirror mode

--- a/CHANGES/5895.bugfix
+++ b/CHANGES/5895.bugfix
@@ -1,1 +1,0 @@
-Building an image from a Containerfile no longer requires root access.

--- a/CHANGES/6069.misc
+++ b/CHANGES/6069.misc
@@ -1,1 +1,0 @@
-Functional tests now use bindings

--- a/CHANGES/6292.feature
+++ b/CHANGES/6292.feature
@@ -1,1 +1,0 @@
-Provide apache and nginx config snippets to be used by the installer.

--- a/pulp_container/__init__.py
+++ b/pulp_container/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.2.0'
+__version__ = '1.3.0.dev'
 
 default_app_config = 'pulp_container.app.PulpContainerPluginAppConfig'

--- a/pulp_container/__init__.py
+++ b/pulp_container/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '1.2.0.dev'
+__version__ = '1.2.0'
 
 default_app_config = 'pulp_container.app.PulpContainerPluginAppConfig'

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    'pulpcore>=3.1.0,<3.3',
+    'pulpcore>=3.2.0,<3.3',
     'ecdsa~=0.13.2',
     'pyjwkest~=1.4.0',
     'pyjwt[crypto]~=1.7.1'
@@ -14,7 +14,7 @@ with open('README.rst') as f:
 
 setup(
     name='pulp-container',
-    version='1.2.0.dev',
+    version='1.2.0',
     description='Container plugin for the Pulp Project',
     long_description=long_description,
     license='GPLv2+',

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 from setuptools import find_packages, setup
 
 requirements = [
-    'pulpcore>=3.2.0,<3.3',
+    'pulpcore>=3.2.0',
     'ecdsa~=0.13.2',
     'pyjwkest~=1.4.0',
     'pyjwt[crypto]~=1.7.1'
@@ -14,7 +14,7 @@ with open('README.rst') as f:
 
 setup(
     name='pulp-container',
-    version='1.2.0',
+    version='1.3.0.dev',
     description='Container plugin for the Pulp Project',
     long_description=long_description,
     license='GPLv2+',


### PR DESCRIPTION
There are 3 commits here: 

- Changelog for 1.2.0
- version bump to 1.2.0
- version bump to 1.3.0.dev

The plan is sto release the second commit as 1.2.0.