### PR TITLE
Rename ansible-pulp to pulp_installer

### DIFF
--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -6,7 +6,7 @@ Ansible Installer (Recommended)
 -------------------------------
 
 We recommend that you install `pulpcore` and `pulp-container` together using the `Ansible installer
-<https://github.com/pulp/ansible-pulp/blob/master/README.md>`_. If you install this way, pulpcore
+<https://github.com/pulp/pulp_installer/blob/master/README.md>`_. If you install this way, pulpcore
 installation and all the following steps will be done for you.
 
 Install ``pulpcore``


### PR DESCRIPTION
[noissue]

re: #6406
Rename ansible-pulp to pulp_installer
https://pulp.plan.io/issues/6406