### PR TITLE
Sets client_max_body_size to 0, unlimited for nginx

### DIFF
--- a/CHANGES/6916.bugfix
+++ b/CHANGES/6916.bugfix
@@ -1,0 +1,1 @@
+Fixed the client_max_body_size value in the nginx config.

--- a/pulp_container/app/webserver_snippets/nginx.conf
+++ b/pulp_container/app/webserver_snippets/nginx.conf
@@ -6,6 +6,7 @@ location /v2/ {
     # redirects, we set the Host: header above already.
     proxy_redirect off;
     proxy_pass http://pulp-api;
+    client_max_body_size 0;
 }
 
 location /pulp/container/ {

--- a/pulp_container/tests/functional/api/test_push_content.py
+++ b/pulp_container/tests/functional/api/test_push_content.py
@@ -33,9 +33,10 @@ class PushContentTestCase(unittest.TestCase):
         """Test push with official registry client"""
         # TODO better handling of the "http://"
         local_url = urljoin(cfg.get_base_url(), 'foo/bar:1.0')[7:]
-        registry.pull("busybox:latest")
-        registry.tag("busybox:latest", local_url)
+        registry.pull("centos:7")
+        registry.tag("centos:7", local_url)
         registry.push(local_url)
+        registry.pull(local_url)
         repository = repositories_api.list(name='foo/bar').results[0]
         distribution = distributions_api.list(name='foo/bar').results[0]
         self.addCleanup(repositories_api.delete, repository.pulp_href)


### PR DESCRIPTION
The default value for client_max_body_size is 1mb. We need it to be unlimited.
    
Apache's equivalent is LimitRequestBody and it defaults to unlimited.
    
This patch updates the 'push' test to use a large image that would require this setting to be set.
    
This patch also adds an additional 'pull' operation to the 'push' test to verify that the pushed
image can be pulled back from the registry.
    
fixes: #6916
https://pulp.plan.io/issues/6916
