### PR TITLE
Redirect tag lookup to content app

### DIFF
--- a/CHANGES/6824.feature
+++ b/CHANGES/6824.feature
@@ -1,0 +1,2 @@
+Redirected get on Manifest get to the content app to enable schema conversion.
+Repaired schema conversion to work with django-storage framework.

--- a/pulp_container/app/schema_convert.py
+++ b/pulp_container/app/schema_convert.py
@@ -1,4 +1,3 @@
-import os
 import base64
 import binascii
 import datetime
@@ -11,7 +10,6 @@ from collections import namedtuple
 from jwkest import jws, jwk, ecc
 
 from django.core.exceptions import ObjectDoesNotExist
-from django.conf import settings
 
 from pulp_container.constants import MEDIA_TYPE
 
@@ -292,6 +290,4 @@ def _get_manifest_dict(manifest):
 
 
 def _get_dict(artifact):
-    with open(os.path.join(settings.MEDIA_ROOT, artifact.file.path)) as json_file:
-        json_string = json_file.read()
-    return json.loads(json_string)
+    return json.load(artifact.file)


### PR DESCRIPTION
Also repaired schema conversion to work with s3 (django-storage).

fixes #6824
https://pulp.plan.io/issues/6824