### PR TITLE
Download content from the S3 storage without issuing a redirect

### DIFF
--- a/CHANGES/6826.feature
+++ b/CHANGES/6826.feature
@@ -1,0 +1,1 @@
+Made the registry to behave like a proxy server when retrieving content from the S3 storage


### PR DESCRIPTION
The pulp-content app now serves as a proxy server when retrieving content from the S3 storage. It downloads the content directly and returns it within the Response object's body.

closes #6826