### PR TITLE
Use the path and query string of the URL to generate a 'validate_token'.

### DIFF
--- a/CHANGES/7462.bugfix
+++ b/CHANGES/7462.bugfix
@@ -1,0 +1,2 @@
+Fixed bug where users would get 403 response when pulling from the registry running behind an HTTPS
+reverse proxy.

--- a/pulp_container/app/models.py
+++ b/pulp_container/app/models.py
@@ -4,6 +4,7 @@ import re
 import time
 from logging import getLogger
 from url_normalize import url_normalize
+from urllib.parse import urlparse
 
 from django.db import models
 from django.conf import settings
@@ -462,9 +463,12 @@ class ContentRedirectContentGuard(ContentGuard):
         return url
 
     def _get_digest(self, salt, url):
+        url_parts = urlparse(url_normalize(url))
         hasher = hashlib.sha256()
         hasher.update(salt)
-        hasher.update(url_normalize(url).encode())
+        hasher.update(url_parts.path.encode())
+        hasher.update(b"?")
+        hasher.update(url_parts.query.encode())
         hasher.update(self.shared_secret)
         return hasher.digest()
 


### PR DESCRIPTION
fixes: #7462
https://pulp.plan.io/issues/7462