### PR TITLE
Remove unused variable

### DIFF
--- a/pulp_container/app/authorization.py
+++ b/pulp_container/app/authorization.py
@@ -1,4 +1,3 @@
-import re
 import base64
 import hashlib
 import random
@@ -13,8 +12,6 @@ from cryptography.hazmat.backends import default_backend
 from cryptography.hazmat.primitives import serialization
 
 TOKEN_EXPIRATION_TIME = 300
-
-KNOWN_SERVICES = [re.sub(r"(http://|https://)", "", settings.CONTENT_ORIGIN, count=1)]
 
 
 class AuthorizationService:


### PR DESCRIPTION
In d23235cfc2e57266715ce1b124c757c7e7416663 the last use of this variable was removed.

I ran into this when trying to understand the use of CONTENT_ORIGIN but I'm unfamiliar with the codebase so I may be missing something.