### PR TITLE
Fixed a bug where Artifacts were missing some checksums after `podman…

### DIFF
--- a/CHANGES/7774.bugfix
+++ b/CHANGES/7774.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug where Artifacts were missing sha224 checksum after `podman push`.

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -452,6 +452,7 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
                     sha256=upload.sha256,
                     sha384=upload.sha384,
                     sha512=upload.sha512,
+                    sha224=upload.sha224,
                     size=upload.file.size,
                 )
                 artifact.save()


### PR DESCRIPTION
… push`.

closes #7774
https://pulp.plan.io/issues/7774