### PR TITLE
Use monitor_task from pulp_smash

### DIFF
--- a/.travis/before_install.sh
+++ b/.travis/before_install.sh
@@ -9,8 +9,11 @@
 
 set -mveuo pipefail
 
+COMPONENT_VERSION=$(sed -ne 's/\s*version=\"\(.*\)\"[\s,]*/\1/p' setup.py)
 mkdir .travis/vars || true
 echo "---" > .travis/vars/main.yaml
+echo "component_name: pulp_container" >> .travis/vars/main.yaml
+echo "component_version: '${COMPONENT_VERSION}'" >> .travis/vars/main.yaml
 
 export PRE_BEFORE_INSTALL=$TRAVIS_BUILD_DIR/.travis/pre_before_install.sh
 export POST_BEFORE_INSTALL=$TRAVIS_BUILD_DIR/.travis/post_before_install.sh

--- a/.travis/filter/repr.py
+++ b/.travis/filter/repr.py
@@ -1,4 +1,5 @@
 from __future__ import absolute_import, division, print_function
+from packaging.version import parse as parse_version
 
 __metaclass__ = type
 
@@ -14,6 +15,10 @@ def _repr_filter(value):
     return repr(value)
 
 
+def _canonical_semver_filter(value):
+    return str(parse_version(value))
+
+
 # ---- Ansible filters ----
 class FilterModule(object):
     """Repr filter."""
@@ -22,4 +27,5 @@ class FilterModule(object):
         """Filter associations."""
         return {
             "repr": _repr_filter,
+            "canonical_semver": _canonical_semver_filter,
         }

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -18,32 +18,7 @@ pip install -r functest_requirements.txt
 
 cd .travis
 
-# Although the tag name is not used outside of this script, we might use it
-# later. And it is nice to have a friendly identifier for it.
-# So we use the branch preferably, but need to replace the "/" with the valid
-# character "_" .
-#
-# Note that there are lots of other valid git branch name special characters
-# that are invalid in image tag names. To try to convert them, this would be a
-# starting point:
-# https://stackoverflow.com/a/50687120
-#
-# If we are on a tag
-if [ -n "$TRAVIS_TAG" ]; then
-  TAG=$(echo $TRAVIS_TAG | tr / _)
-# If we are on a PR
-elif [ -n "$TRAVIS_PULL_REQUEST_BRANCH" ]; then
-  TAG=$(echo $TRAVIS_PULL_REQUEST_BRANCH | tr / _)
-# For push builds and hopefully cron builds
-elif [ -n "$TRAVIS_BRANCH" ]; then
-  TAG=$(echo $TRAVIS_BRANCH | tr / _)
-  if [ "${TAG}" = "master" ]; then
-    TAG=latest
-  fi
-else
-  # Fallback
-  TAG=$(git rev-parse --abbrev-ref HEAD | tr / _)
-fi
+TAG=ci_build
 if [ -n "$TRAVIS_TAG" ]; then
   # Install the plugin only and use published PyPI packages for the rest
   # Quoting ${TAG} ensures Ansible casts the tag as a string.

--- a/.travis/start_container.yaml
+++ b/.travis/start_container.yaml
@@ -81,6 +81,14 @@
           command: "docker logs pulp"
           failed_when: true
 
+    - name: "Check version of component being tested"
+      assert:
+        that:
+          - (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] | canonical_semver == (component_version | canonical_semver)
+        fail_msg: |
+          Component {{ component_name }} was expected to be installed in version {{ component_version }}.
+          Instead it is reported as version {{ (result.json.versions | items2dict(key_name="component", value_name="version"))[component_name] }}.
+
     - name: "Set pulp password in .netrc"
       copy:
         dest: "~/.netrc"

--- a/pulp_container/tests/functional/api/test_crud_content_unit.py
+++ b/pulp_container/tests/functional/api/test_crud_content_unit.py
@@ -2,13 +2,13 @@
 """Tests that CRUD container content units."""
 import unittest
 
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import delete_orphans
 
 from pulp_container.tests.functional.utils import (
     gen_artifact,
     gen_container_client,
     gen_container_content_attrs,
-    monitor_task,
     skip_if,
 )
 from pulpcore.client.pulp_container import ContentManifestsApi

--- a/pulp_container/tests/functional/api/test_crud_distributions.py
+++ b/pulp_container/tests/functional/api/test_crud_distributions.py
@@ -6,12 +6,12 @@ import unittest
 from itertools import permutations
 
 from pulp_smash import utils
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_distribution
 
 from pulp_container.tests.functional.utils import (
     skip_if,
     gen_container_client,
-    monitor_task,
 )
 
 from pulpcore.client.pulp_container import (

--- a/pulp_container/tests/functional/api/test_crud_remotes.py
+++ b/pulp_container/tests/functional/api/test_crud_remotes.py
@@ -4,12 +4,12 @@ from random import choice
 import unittest
 
 from pulp_smash import utils
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.constants import ON_DEMAND_DOWNLOAD_POLICIES
 
 from pulp_container.tests.functional.utils import (
     gen_container_client,
     gen_container_remote,
-    monitor_task,
     skip_if,
 )
 

--- a/pulp_container/tests/functional/api/test_pull_content.py
+++ b/pulp_container/tests/functional/api/test_pull_content.py
@@ -6,6 +6,7 @@ import unittest
 from urllib.parse import urljoin
 
 from pulp_smash import api, cli, config, exceptions
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import (
     delete_orphans,
     get_content,
@@ -18,7 +19,6 @@ from pulp_container.tests.functional.utils import (
     gen_container_client,
     gen_container_remote,
     get_docker_hub_remote_blobsums,
-    monitor_task,
     BearerTokenAuth,
     AuthenticationHeaderQueries,
 )

--- a/pulp_container/tests/functional/api/test_recursive_add.py
+++ b/pulp_container/tests/functional/api/test_recursive_add.py
@@ -2,12 +2,12 @@
 """Tests that recursively add container content to repositories."""
 import unittest
 
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_repo
 
 from pulp_container.tests.functional.utils import (
     gen_container_remote,
     gen_container_client,
-    monitor_task,
 )
 from pulp_container.tests.functional.constants import DOCKERHUB_PULP_FIXTURE_1
 

--- a/pulp_container/tests/functional/api/test_recursive_remove.py
+++ b/pulp_container/tests/functional/api/test_recursive_remove.py
@@ -2,12 +2,12 @@
 """Tests that recursively remove container content from repositories."""
 import unittest
 
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_repo
 
 from pulp_container.tests.functional.utils import (
     gen_container_remote,
     gen_container_client,
-    monitor_task,
 )
 from pulp_container.tests.functional.constants import DOCKERHUB_PULP_FIXTURE_1
 

--- a/pulp_container/tests/functional/api/test_repositories_list.py
+++ b/pulp_container/tests/functional/api/test_repositories_list.py
@@ -6,6 +6,7 @@ from urllib.parse import urljoin
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_distribution, gen_repo
 
 from pulp_container.tests.functional.constants import DOCKERHUB_PULP_FIXTURE_1
@@ -13,7 +14,6 @@ from pulp_container.tests.functional.constants import DOCKERHUB_PULP_FIXTURE_1
 from pulp_container.tests.functional.utils import (
     gen_container_remote,
     gen_container_client,
-    monitor_task,
     BearerTokenAuth,
     AuthenticationHeaderQueries,
 )

--- a/pulp_container/tests/functional/api/test_tagging_images.py
+++ b/pulp_container/tests/functional/api/test_tagging_images.py
@@ -2,12 +2,12 @@
 """Tests for tagging and untagging images."""
 import unittest
 
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_repo
 
 from pulp_container.tests.functional.utils import (
     gen_container_remote,
     gen_container_client,
-    monitor_task,
 )
 from pulp_container.tests.functional.constants import (
     CONTAINER_TAG_PATH,

--- a/pulp_container/tests/functional/api/test_token_authentication.py
+++ b/pulp_container/tests/functional/api/test_token_authentication.py
@@ -6,12 +6,12 @@ from urllib.parse import urljoin
 from requests.exceptions import HTTPError
 
 from pulp_smash import api, config, cli
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_repo, gen_distribution
 
 from pulp_container.tests.functional.utils import (
     gen_container_remote,
     gen_container_client,
-    monitor_task,
     BearerTokenAuth,
     AuthenticationHeaderQueries,
 )

--- a/pulp_container/tests/functional/utils.py
+++ b/pulp_container/tests/functional/utils.py
@@ -5,10 +5,10 @@ import requests
 from requests.auth import AuthBase
 from functools import partial
 from unittest import SkipTest
-from time import sleep
 from tempfile import NamedTemporaryFile
 
 from pulp_smash import selectors, config
+from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import (
     gen_remote,
     gen_repo,
@@ -159,27 +159,3 @@ def gen_artifact(url=CONTAINER_IMAGE_URL):
         temp_file.write(response.content)
         artifact = ArtifactsApi(core_client).create(file=temp_file.name)
         return artifact.to_dict()
-
-
-def monitor_task(task_href):
-    """Poll the Task API until the task is in a completed state.
-
-    Print the task details and a success or failure message. Exits on failure.
-
-    Args:
-        task_href(str): The href of the task to monitor.
-
-    Returns:
-        list[str]: A list of hrefs that identify resource created by the task.
-
-    """
-    completed = ["completed", "failed", "canceled"]
-    task = tasks.read(task_href)
-    while task.state not in completed:
-        sleep(2)
-        task = tasks.read(task_href)
-
-    if task.state == "completed":
-        return task.created_resources
-
-    return task.to_dict()


### PR DESCRIPTION
This version is throwing PulpTaskError on failed tasks, so tasks will
not longer fail silently in the tests.

[noissue]