### PR TITLE
Remove md5 checksum from allowed checksums when running tests in CI

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -72,7 +72,7 @@ VARSYAML
 fi
 
 cat >> vars/main.yaml << VARSYAML
-pulp_settings: {}
+pulp_settings: {"allowed_content_checksums": ["sha1", "sha224", "sha256", "sha384", "sha512"]}
 VARSYAML
 
 if [ "$TEST" = "s3" ]; then

--- a/CHANGES/7936.misc
+++ b/CHANGES/7936.misc
@@ -1,0 +1,1 @@
+Updated CI scripts to exclude md5 checksum when running tests in CI.

--- a/template_config.yml
+++ b/template_config.yml
@@ -37,7 +37,13 @@ plugin_dash_short: container
 plugin_name: pulp_container
 plugin_snake: pulp_container
 publish_docs_to_pulpprojectdotorg: true
-pulp_settings: {}
+pulp_settings:
+  allowed_content_checksums:
+  - sha1
+  - sha224
+  - sha256
+  - sha384
+  - sha512
 pulpcore_branch: master
 pulpcore_pip_version_specifier: null
 pulpprojectdotorg_key_id: aa499d7938ed


### PR DESCRIPTION
fixes: #7936