### PR TITLE
Push pull ap

### DIFF
--- a/CHANGES/8075.feature
+++ b/CHANGES/8075.feature
@@ -1,0 +1,1 @@
+Made the push and pull permission granting use the ``ContainerDistribution`` access policy.

--- a/pulp_container/app/access_policy.py
+++ b/pulp_container/app/access_policy.py
@@ -1,3 +1,6 @@
+from rest_access_policy import AccessPolicy
+
+from pulpcore.plugin.models import AccessPolicy as AccessPolicyModel
 from pulpcore.plugin.access_policy import AccessPolicyFromDB
 
 from pulp_container.app import models
@@ -24,9 +27,9 @@ class NamespacePermissionsChecker:
             return user.has_perm(permission) or user.has_perm(permission, namespace)
 
 
-class DistributionAccessPolicyFromDB(AccessPolicyFromDB):
+class DistributionAccessPolicyMixin:
     """
-    Access policy for DistributionViewSet which handles namespace permissions.
+    Access policy mixin for DistributionViewSet which handles namespace permissions.
     """
 
     def has_manage_namespace_dist_perms(self, request, view, action, permission):
@@ -43,3 +46,45 @@ class DistributionAccessPolicyFromDB(AccessPolicyFromDB):
         """
         namespace = view.get_object().namespace
         return request.user.has_perm(permission, namespace)
+
+    def obj_exists(self, request, view, action):
+        """
+        Check if the distribution exists.
+        """
+        return view.get_object() is not None
+
+    def is_private(self, request, view, action):
+        """
+        Check if the distribution is marked private.
+        """
+        return view.get_object().private
+
+
+class DistributionAccessPolicyFromDB(AccessPolicyFromDB, DistributionAccessPolicyMixin):
+    """
+    Access policy for DistributionViewSet which handles namespace permissions.
+    """
+
+
+class RegistryAccessPolicy(AccessPolicy, DistributionAccessPolicyMixin):
+    """
+    An AccessPolicy that loads statements from the container distribution viewset.
+    """
+
+    def get_policy_statements(self, request, view):
+        """
+        Return the policy statements for the container distribution viewset.
+
+        Args:
+            request (rest_framework.request.Request): The request being checked for authorization.
+            view (subclass rest_framework.viewsets.GenericViewSet): The view name being requested.
+
+        Returns:
+            The access policy statements in drf-access-policy policy structure.
+
+        """
+
+        access_policy_obj = AccessPolicyModel.objects.get(
+            viewset_name="distributions/container/container"
+        )
+        return access_policy_obj.statements

--- a/pulp_container/app/viewsets.py
+++ b/pulp_container/app/viewsets.py
@@ -634,6 +634,11 @@ class ContainerDistributionViewSet(BaseDistributionViewSet):
                 "effect": "allow",
             },
             {
+                "action": ["catalog"],
+                "principal": "authenticated",
+                "effect": "allow",
+            },
+            {
                 "action": ["create"],
                 "principal": "authenticated",
                 "effect": "allow",
@@ -651,7 +656,15 @@ class ContainerDistributionViewSet(BaseDistributionViewSet):
                 ],
             },
             {
-                "action": [],
+                "action": ["pull"],
+                "principal": "*",
+                "effect": "allow",
+                "condition": [
+                    "not is_private",
+                ],
+            },
+            {
+                "action": ["pull"],
                 "principal": "authenticated",
                 "effect": "allow",
                 "condition": [
@@ -667,11 +680,21 @@ class ContainerDistributionViewSet(BaseDistributionViewSet):
                 ],
             },
             {
-                "action": [],
+                "action": ["push"],
                 "principal": "authenticated",
                 "effect": "allow",
                 "condition": [
                     "has_model_or_obj_perms:container.push_containerdistribution",
+                    "obj_exists",
+                ],
+            },
+            {
+                "action": ["push"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": [
+                    "has_model_perms:container.add_containerdistribution",
+                    "has_manage_namespace_dist_perms:container.manage_namespace_distributions",
                 ],
             },
             {


### PR DESCRIPTION
~This is far from a working example~, but i was wondering if there's a way we can use the access_policy framework already in place to decide on the token permissions.
That way we could make the question whether a not-private repo is world readable or only available to logged in users part of the distribution access policy.