### PR TITLE
Add support for tagging and untagging for push repositories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,5 @@ venv.bak/
 .vscode/
 .idea/
 
+# A generated API schema
+docs/_static/api.json

--- a/CHANGES/8104.feature
+++ b/CHANGES/8104.feature
@@ -1,0 +1,1 @@
+Added support for tagging and untagging manifests for push repositories.

--- a/docs/workflows/manage-content.rst
+++ b/docs/workflows/manage-content.rst
@@ -9,10 +9,6 @@ There are multiple ways that users can manage Container content in repositories:
    2. Recursively :ref:`add<recursive-add>` or :ref:`remove<recursive-remove>` Container content.
    3. Copy :ref:`tags<tag-copy>` or :ref:`manifests <manifest-copy>` from source repository.
 
-.. note::
-   In a push repository it is not possible to perform any tagging, additon or removal of content via the Pulp API.
-   However, it is possible to use a push repository as a source repository in copy operations.
-
 Each of these workflows kicks off a task, and when the task is complete,
 a new repository version will have been created.
 

--- a/pulp_container/app/tasks/tag.py
+++ b/pulp_container/app/tasks/tag.py
@@ -1,5 +1,5 @@
-from pulpcore.plugin.models import ContentArtifact, CreatedResource
-from pulp_container.app.models import ContainerRepository, Manifest, Tag
+from pulpcore.plugin.models import ContentArtifact, CreatedResource, Repository
+from pulp_container.app.models import Manifest, Tag
 
 
 def tag_image(manifest_pk, tag, repository_pk):
@@ -15,7 +15,7 @@ def tag_image(manifest_pk, tag, repository_pk):
     manifest = Manifest.objects.get(pk=manifest_pk)
     artifact = manifest._artifacts.all()[0]
 
-    repository = ContainerRepository.objects.get(pk=repository_pk)
+    repository = Repository.objects.get(pk=repository_pk).cast()
     latest_version = repository.latest_version()
 
     tags_to_remove = Tag.objects.filter(pk__in=latest_version.content.all(), name=tag).exclude(

--- a/pulp_container/app/tasks/untag.py
+++ b/pulp_container/app/tasks/untag.py
@@ -1,11 +1,12 @@
-from pulp_container.app.models import ContainerRepository, Tag
+from pulpcore.plugin.models import Repository
+from pulp_container.app.models import Tag
 
 
 def untag_image(tag, repository_pk):
     """
     Create a new repository version without a specified manifest's tag name.
     """
-    repository = ContainerRepository.objects.get(pk=repository_pk)
+    repository = Repository.objects.get(pk=repository_pk).cast()
     latest_version = repository.latest_version()
 
     tags_in_latest_repository = latest_version.content.filter(pulp_type="container.tag")


### PR DESCRIPTION
Note that in this commit, there are not handled race conditions where a container client simulateneously tries to push a tag that is being created in an asynchronous task invoked via the Pulp API.

closes #8104