### PR TITLE
Change is_private check to is_public

### DIFF
--- a/pulp_container/app/access_policy.py
+++ b/pulp_container/app/access_policy.py
@@ -53,11 +53,11 @@ class DistributionAccessPolicyMixin:
         """
         return view.get_object() is not None
 
-    def is_private(self, request, view, action):
+    def is_public(self, request, view, action):
         """
         Check if the distribution is marked private.
         """
-        return view.get_object().private
+        return not view.get_object().private
 
 
 class DistributionAccessPolicyFromDB(AccessPolicyFromDB, DistributionAccessPolicyMixin):

--- a/pulp_container/app/viewsets.py
+++ b/pulp_container/app/viewsets.py
@@ -660,7 +660,7 @@ class ContainerDistributionViewSet(BaseDistributionViewSet):
                 "principal": "*",
                 "effect": "allow",
                 "condition": [
-                    "not is_private",
+                    "is_public",
                 ],
             },
             {


### PR DESCRIPTION
drf-access-policy expects the condition to be a method name. 'not is_private' is not a method name on the viewset. 

[noissue]