### PR TITLE
Change queryset filter for ContainerDistribution

### DIFF
--- a/CHANGES/8206.bugfix
+++ b/CHANGES/8206.bugfix
@@ -1,0 +1,1 @@
+Adjusted the queryset filtering of ``ContainerDistribution`` to include ``private`` and ``Namespace`` permissions.


### PR DESCRIPTION
The new implementation takes the private flag as well as namespace
permissions into account.

fixes #8206