### PR TITLE
Use get_user_model instead of auth.models.user

### DIFF
--- a/CHANGES/8260.bugfix
+++ b/CHANGES/8260.bugfix
@@ -1,0 +1,1 @@
+Use ``get_user_model()`` to prevent pulp_container from crashing when running alongside other pulp plugins that override the default user authentication models. 

--- a/pulp_container/app/token_verification.py
+++ b/pulp_container/app/token_verification.py
@@ -1,11 +1,14 @@
 import jwt
 
 from django.conf import settings
-from django.contrib.auth.models import AnonymousUser, User
+from django.contrib.auth.models import AnonymousUser
+from django.contrib.auth import get_user_model
 
 from rest_framework.authentication import BaseAuthentication
 from rest_framework.exceptions import AuthenticationFailed
 from rest_framework.permissions import BasePermission, SAFE_METHODS
+
+User = get_user_model()
 
 
 def _decode_token(encoded_token, request):


### PR DESCRIPTION
Importing and using `django.contrib.auth.models.User` breaks any apps that use custom user models defined in `AUTH_USER_MODEL`. To prevent this from happening, the `User` model should be loaded using django's `get_user_model()` function.

See https://docs.djangoproject.com/en/3.1/topics/auth/customizing/#referencing-the-user-model for details