### PR TITLE
Allow user to add a namespace matching their login

### DIFF
--- a/CHANGES/8197.feature
+++ b/CHANGES/8197.feature
@@ -1,0 +1,2 @@
+Added a `namespace_is_username` helper to decide whether the namespace matches the username of the requests user.
+Changed the namespace access_policy to allow users without permissions to create the namespace that matches their username.

--- a/docs/role-based-access-control.rst
+++ b/docs/role-based-access-control.rst
@@ -30,9 +30,10 @@ repositories. Namespaces provide a naming convention for container repositories.
 the ``foo`` namespace are named ``foo/something`` and ``foo/something-else``.
 
 The default access policy for ``pulp_container/namespaces`` requires a user to have the
-``container.add_containernamespace`` permission to create a new namespace. The new namespace can be
-created by pushing an image using ``podman`` or ``docker`` client. This same permission allows the user
-of Pulp's API to create a new namespace.
+``container.add_containernamespace`` permission to create a new namespace. Alternatively a user is
+allowed to create a namespace that matches his username if it did not exist before. The new
+namespace can be created by pushing an image using ``podman`` or ``docker`` client. This same
+permissions allow the user of Pulp's API to create a new namespace.
 
 The creation of a new namespace creates three user groups that can access the namespace:
 Owners, Collaborators, and Consumers. The user that creates the namespace is automatically added to

--- a/pulp_container/app/viewsets.py
+++ b/pulp_container/app/viewsets.py
@@ -797,7 +797,7 @@ class ContainerPushRepositoryViewSet(TagOperationsMixin, ReadOnlyRepositoryViewS
     endpoint_name = "container-push"
     queryset = models.ContainerPushRepository.objects.all()
     serializer_class = serializers.ContainerPushRepositorySerializer
-    permission_classes = (access_policy.NamespaceAccessPolicyFromDB,)
+    permission_classes = (access_policy.NamespacedAccessPolicyFromDB,)
 
     DEFAULT_ACCESS_POLICY = {
         "statements": [
@@ -961,7 +961,7 @@ class ContainerDistributionViewSet(BaseDistributionViewSet):
     queryset = models.ContainerDistribution.objects.all()
     serializer_class = serializers.ContainerDistributionSerializer
     filterset_class = ContainerDistributionFilter
-    permission_classes = (access_policy.NamespaceAccessPolicyFromDB,)
+    permission_classes = (access_policy.NamespacedAccessPolicyFromDB,)
 
     DEFAULT_ACCESS_POLICY = {
         "statements": [
@@ -1178,7 +1178,7 @@ class ContainerNamespaceViewSet(
     queryset = models.ContainerNamespace.objects.all()
     serializer_class = serializers.ContainerNamespaceSerializer
     filterset_class = ContainerNamespaceFilter
-    permission_classes = (AccessPolicyFromDB,)
+    permission_classes = (access_policy.NamespaceAccessPolicy,)
     queryset_filtering_required_permission = "container.view_containernamespace"
 
     DEFAULT_ACCESS_POLICY = {
@@ -1193,6 +1193,12 @@ class ContainerNamespaceViewSet(
                 "principal": "authenticated",
                 "effect": "allow",
                 "condition": "has_model_perms:container.add_containernamespace",
+            },
+            {
+                "action": ["create"],
+                "principal": "authenticated",
+                "effect": "allow",
+                "condition": "namespace_is_username",
             },
             {
                 "action": ["retrieve"],

--- a/pulp_container/tests/functional/api/test_push_content.py
+++ b/pulp_container/tests/functional/api/test_push_content.py
@@ -269,3 +269,22 @@ class PushRepoTestCase(unittest.TestCase, rbac_base.BaseRegistryTest):
         # cleanup, namespace removal also removes related distributions
         namespace = self.namespace_api.list(name="test").results[0]
         self.addCleanup(self.namespace_api.delete, namespace.pulp_href)
+
+    def test_matching_username(self):
+        """
+        Test that you can push to a nonexisting nameespace that matches your username.
+        """
+        namespace_name = self.user_helpless["username"]
+        repo_name = f"{namespace_name}/matching"
+        local_url = "/".join([self.registry_name, f"{repo_name}:2.0"])
+        invalid_local_url = "/".join([self.registry_name, f"other/{repo_name}:2.0"])
+        image_path = f"{DOCKERHUB_PULP_FIXTURE_1}:manifest_a"
+
+        self._push(image_path, local_url, self.user_helpless)
+
+        with self.assertRaises(exceptions.CalledProcessError):
+            self._push(image_path, invalid_local_url, self.user_helpless)
+
+        # cleanup, namespace removal also removes related distributions
+        namespace = self.namespace_api.list(name=namespace_name).results[0]
+        self.addCleanup(self.namespace_api.delete, namespace.pulp_href)


### PR DESCRIPTION
This is a change to the default access policy accompanied by a helper
function `namespace_is_username` for  access policies.

fixes #8197
https://pulp.plan.io/issues/8197