### PR TITLE
Return an empty string when the key does not exist

### DIFF
--- a/CHANGES/8299.bugfix
+++ b/CHANGES/8299.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug that caused the registry to fail during the schema conversion when there was not
+provided the field ``created_by``.

--- a/pulp_container/app/schema_convert.py
+++ b/pulp_container/app/schema_convert.py
@@ -193,9 +193,12 @@ class Schema2toSchema1Converter:
             config.pop("history", None)
             config.pop("rootfs", None)
         else:
+            # both `created` and `created_by` are optional according to the OCI specs
+            container_config = dict(Cmd=[fs_layer.history.get("created_by", "")])
+            created = fs_layer.history.get("created", "")
             config = dict(
-                created=fs_layer.history["created"],
-                container_config=dict(Cmd=fs_layer.history["created_by"]),
+                created=created,
+                container_config=container_config,
             )
         if fs_layer.uncompressed_digest is None:
             config["throwaway"] = True

--- a/pulp_container/tests/unit/test_convert.py
+++ b/pulp_container/tests/unit/test_convert.py
@@ -26,6 +26,7 @@ class Test(TestCase):
             empty,
             empty,
             empty,
+            empty,
             dict(blobSum="sha256:base"),
         ] == cnv.fs_layers
 
@@ -52,23 +53,27 @@ class Test(TestCase):
             empty,
             empty,
             empty,
+            empty,
             dict(blobSum="sha256:base"),
         ] == cnv.fs_layers
         assert [
             {
-                "v1Compatibility": '{"architecture":"amd64","author":"Mihai Ibanescu <mihai.ibanescu@gmail.com>","config":{"Cmd":["/bin/bash"],"Hostname":"decafbad"},"container_config":{"Hostname":"decafbad","Tty":false},"created":"2019-09-05T21:28:52.173079282Z","docker_version":"1.13.1","id":"d7b329ed9d186ff20c25399e848116430ee9b6ae022cb9f3dc3406144ec3685d","parent":"6474547c15d178825c70a42efdc59a88c6e30d764d184b415f32484562803446"}'  # noqa
+                "v1Compatibility": '{"architecture":"amd64","author":"Mihai Ibanescu <mihai.ibanescu@gmail.com>","config":{"Cmd":["/bin/bash"],"Hostname":"decafbad"},"container_config":{"Hostname":"decafbad","Tty":false},"created":"2019-09-05T21:28:52.173079282Z","docker_version":"1.13.1","id":"8e1cc996a0d319582f770dbded72777c5b8c5c46859c506db5acc674bc42ee51","parent":"3d0d31cc2270f872e56b7b7e35fb4fb7796797a8979ae180a2baee7107a5eb5b"}'  # noqa
             },
             {
-                "v1Compatibility": '{"container_config":{"Cmd":"/bin/sh -c #(nop)  MAINTAINER Mihai Ibanescu <mihai.ibanescu@gmail.com>"},"created":"2019-09-05T21:28:43.305854958Z","id":"6474547c15d178825c70a42efdc59a88c6e30d764d184b415f32484562803446","parent":"5708420291e0a86d8dc08ec40b2c1b1799117c33fe85032b87227632f70c1018","throwaway":true}'  # noqa
+                "v1Compatibility": '{"container_config":{"Cmd":[""]},"created":"2019-09-05T21:28:46.173079282Z","id":"3d0d31cc2270f872e56b7b7e35fb4fb7796797a8979ae180a2baee7107a5eb5b","parent":"6474547c15d178825c70a42efdc59a88c6e30d764d184b415f32484562803446","throwaway":true}'  # noqa
             },
             {
-                "v1Compatibility": '{"container_config":{"Cmd":"/bin/sh -c #(nop)  CMD [\\"/bin/bash\\"]"},"created":"2018-03-06T00:48:12.679169547Z","id":"5708420291e0a86d8dc08ec40b2c1b1799117c33fe85032b87227632f70c1018","parent":"9e9220abceaf86f2ad7820ae8124d01223d8ec022b9a6cb8c99a8ae1747137ea","throwaway":true}'  # noqa
+                "v1Compatibility": '{"container_config":{"Cmd":["/bin/sh -c #(nop)  MAINTAINER Mihai Ibanescu <mihai.ibanescu@gmail.com>"]},"created":"2019-09-05T21:28:43.305854958Z","id":"6474547c15d178825c70a42efdc59a88c6e30d764d184b415f32484562803446","parent":"5708420291e0a86d8dc08ec40b2c1b1799117c33fe85032b87227632f70c1018","throwaway":true}'  # noqa
             },
             {
-                "v1Compatibility": '{"container_config":{"Cmd":"/bin/sh -c #(nop)  LABEL name=CentOS Base Image vendor=CentOS license=GPLv2 build-date=20180302"},"created":"2018-03-06T00:48:12.458578213Z","id":"9e9220abceaf86f2ad7820ae8124d01223d8ec022b9a6cb8c99a8ae1747137ea","parent":"cb48c1db9c0a1ede7c85c85351856fc3e40e750931295c8fac837c63b403586a","throwaway":true}'  # noqa
+                "v1Compatibility": '{"container_config":{"Cmd":["/bin/sh -c #(nop)  CMD [\\"/bin/bash\\"]"]},"created":"2018-03-06T00:48:12.679169547Z","id":"5708420291e0a86d8dc08ec40b2c1b1799117c33fe85032b87227632f70c1018","parent":"9e9220abceaf86f2ad7820ae8124d01223d8ec022b9a6cb8c99a8ae1747137ea","throwaway":true}'  # noqa
             },
             {
-                "v1Compatibility": '{"container_config":{"Cmd":"/bin/sh -c #(nop) ADD file:FILE_CHECKSUM in / "},"created":"2018-03-06T00:48:12.077095981Z","id":"cb48c1db9c0a1ede7c85c85351856fc3e40e750931295c8fac837c63b403586a"}'  # noqa
+                "v1Compatibility": '{"container_config":{"Cmd":["/bin/sh -c #(nop)  LABEL name=CentOS Base Image vendor=CentOS license=GPLv2 build-date=20180302"]},"created":"2018-03-06T00:48:12.458578213Z","id":"9e9220abceaf86f2ad7820ae8124d01223d8ec022b9a6cb8c99a8ae1747137ea","parent":"cb48c1db9c0a1ede7c85c85351856fc3e40e750931295c8fac837c63b403586a","throwaway":true}'  # noqa
+            },
+            {
+                "v1Compatibility": '{"container_config":{"Cmd":["/bin/sh -c #(nop) ADD file:FILE_CHECKSUM in / "]},"created":"2018-03-06T00:48:12.077095981Z","id":"cb48c1db9c0a1ede7c85c85351856fc3e40e750931295c8fac837c63b403586a"}'  # noqa
             },
         ] == cnv.history
 
@@ -151,6 +156,10 @@ CONFIG_LAYER = dict(
             "created": "2019-09-05T21:28:43.305854958Z",
             "author": "Mihai Ibanescu <mihai.ibanescu@gmail.com>",
             "created_by": "/bin/sh -c #(nop)  MAINTAINER Mihai Ibanescu <mihai.ibanescu@gmail.com>",
+            "empty_layer": True,
+        },
+        {
+            "created": "2019-09-05T21:28:46.173079282Z",
             "empty_layer": True,
         },
         {


### PR DESCRIPTION
In this commit, there was also fixed the output format of the field `Cmd`.

In the past, we had been returning:
\"container_config\":{\"Cmd\":\"/bin/sh -c #(nop) ADD file:ab8940a9b8a62d2f2c4634bf5e63a87ea73736bd0313412e41be2351c4fbdf53 in / \"}.

As of now, the command is wrapped by a list:
\"container_config\":{\"Cmd\":[\"/bin/sh -c #(nop) ADD file:ab8940a9b8a62d2f2c4634bf5e63a87ea73736bd0313412e41be2351c4fbdf53 in / \"]}

closes #8299