### PR TITLE
Add 429 polling to BlobUpload commit

### DIFF
--- a/CHANGES/8151.bugfix
+++ b/CHANGES/8151.bugfix
@@ -1,0 +1,1 @@
+Wrapped the repository version creation during blob upload commit in a task that will be waited on by issuing 429.


### PR DESCRIPTION
Opening this to have a place to discuss the current attempt to the solution.

Thinks to keep in mind / discuss:
- I believe this works as designed for blob upload. There we are in the lucky position, that the Upload pk is a unique id that can only be used once.
- With tagging manifests, this will be more complicated.
  - It would be nice to be able to calculate some identifier of a request that will be preserved after a 429 retry. This would solve the problem at hand in a more general way (It would basically be task polling written in HTTP language).
- Immediately waiting for the task <=1s before sending the first 429 is not yet implemented (mostly to show that the 429 mechanism actually works).
- Is it OK to insert an arbitrary string as a task_reserved_resource here?