### PR TITLE
Updated Range header in the blob upload response so it is inclusive.

### DIFF
--- a/CHANGES/8545.bugfix
+++ b/CHANGES/8545.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug where image push of the same tag with docker client ended up in the different manifest upload.
+Updated Range header in the blob upload response so it is inclusive. (Backported from https://pulp.plan.io/issues/8543)

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -161,7 +161,7 @@ class UploadResponse(Response):
         headers = {
             "Docker-Upload-UUID": upload.pk,
             "Location": f"/v2/{path}/blobs/uploads/{upload.pk}",
-            "Range": f"0-{upload.size}",
+            "Range": "0-{offset}".format(offset=int(upload.size - 1)),
             "Content-Length": content_length,
         }
         super().__init__(headers=headers, status=202)


### PR DESCRIPTION
closes #8545
backports: #8543

(cherry picked from commit 79478784757fcf0e64f64bbc714063c06ad7b64d)