### PR TITLE
Building changelog for 2.5.1

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,21 @@ Changelog
 
 .. towncrier release notes start
 
+2.5.1 (2021-04-13)
+==================
+
+
+Bugfixes
+--------
+
+- Fixed a bug where image push of the same tag with docker client ended up in the different manifest upload.
+  Updated Range header in the blob upload response so it is inclusive. (Backported from https://pulp.plan.io/issues/8543)
+  `#8545 <https://pulp.plan.io/issues/8545>`_
+
+
+----
+
+
 2.5.0 (2021-04-08)
 ==================
 


### PR DESCRIPTION
[noissue]

(cherry picked from commit bc4a07d32c446d0fcb4e01fed4bb967115fee240)