### PR TITLE
Fix a race while creating push repositories

### DIFF
--- a/CHANGES/8591.bugfix
+++ b/CHANGES/8591.bugfix
@@ -1,0 +1,1 @@
+Add a fix to prevent server errors on push of new repositories including multiple layers. (Backported from https://pulp.plan.io/issues/8565)


### PR DESCRIPTION
This bug is highly reproducable when pushing multilayer images to a not
yet existing repository.

backports #8591

fixes #8565

(cherry picked from commit 1bc6e0fea54857ae09ac1b544d343bd168cc260f)