### PR TITLE
Change phrasing for repoversion

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,7 +12,7 @@ Features
 
 * :ref:`Synchronize <sync-workflow>` container image repositories hosted on Docker-hub, Google Container Registry,
   Quay.io, etc., in mirror or additive mode
-* :ref:`Create Versioned Repositories <versioned-repo-created>` so every operation is a restorable snapshot
+* Automatically :ref:`Creates Versioned Repositories <versioned-repo-created>` so every operation is a restorable snapshot
 * :ref:`Download content on-demand <create-remote>` when requested by clients to reduce disk space
 * :ref:`Perform docker/podman pull <host>` from a container distribution served by Pulp
 * :ref:`Perform docker/podman push <push-workflow>` to the Pulp Registry

--- a/docs/workflows/sync.rst
+++ b/docs/workflows/sync.rst
@@ -84,7 +84,7 @@ sync with. You are telling pulp to fetch content from the remote and add to the 
     In the above example, the payload contains the field ``mirror=False``. This means that the
     sync will be run in the additive mode only. Set ``mirror`` to ``True`` and Pulp will pull
     in new content and remove content which was also removed from upstream.
-    The same logic will be applied when ``include/exclude_tags`` are specified together with 
+    The same logic will be applied when ``include/exclude_tags`` are specified together with
     the ``mirror`` command, but only on the subset of tags.
 
 .. note::
@@ -95,6 +95,15 @@ Reference: `Container Sync Usage <../restapi.html#operation/remotes_container_co
 
 
 .. _versioned-repo-created:
+
+Every time you change a repository, a new repository version is created.
+
+To retrieve a list of repository versions, use the following example request:
+
+.. code-block:: bash
+
+    http $BASE_URL/pulp/api/v3/repositories/container/<uuid>/versions/
+
 
 Repository Version GET Response (when complete):
 


### PR DESCRIPTION
[noissue]

Problem: 
The way the Versioning is listed in the features, it reads like there are calls to create a repo version specifically. 
There is no workflow for this, and from what I understand it is automatic. 
I would like to introduce this example of a GET response better also: 
https://docs.pulpproject.org/pulp_container/workflows/sync.html#versioned-repo-created
In my opinion, the user lands here and is given no context. 
Could we add some introductory here? Any suggestions? I'd happily do it as part of this PR.