### PR TITLE
No wait in Throttled

### DIFF
--- a/CHANGES/8576.bugfix
+++ b/CHANGES/8576.bugfix
@@ -1,0 +1,1 @@
+Do not suggest a time to wait on 429 responses. This allows clients to decide to play nice and increase backoff times.

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -658,7 +658,7 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
                 blob = models.Blob.objects.get(digest=digest)
                 return BlobResponse(blob, path, 201, request)
             elif task.state in ["waiting", "running"]:
-                raise Throttled(wait=5)
+                raise Throttled()
             else:
                 task.delete()
                 raise Exception("Failed.")
@@ -715,7 +715,7 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
                 else:
                     task.delete()
                     raise Exception("Failed.")
-            raise Throttled(wait=5)
+            raise Throttled()
         else:
             raise Exception("The digest did not match")
 
@@ -867,7 +867,7 @@ class Manifests(RedirectsMixin, ContainerRegistryApiMixin, ViewSet):
             else:
                 task.delete()
                 raise Exception("Failed.")
-        raise Throttled(wait=5)
+        raise Throttled()
 
     def receive_artifact(self, chunk):
         """Handles assembling of Manifest as it's being uploaded."""


### PR DESCRIPTION
Stop to tell the client to wait for a specific amount. This way, well
behaved clients will increase their waiting time exponentially while
retrying.

fixes #8576
https://pulp.plan.io/issues/8576