### PR TITLE
Allow users with namespace permissions to update distributions.

### DIFF
--- a/CHANGES/8618.bugfix
+++ b/CHANGES/8618.bugfix
@@ -1,0 +1,1 @@
+Fix a bug where users with container.namespace_change_containerdistribution couldn't change distributions.

--- a/pulp_container/app/viewsets.py
+++ b/pulp_container/app/viewsets.py
@@ -1010,7 +1010,7 @@ class ContainerDistributionViewSet(BaseDistributionViewSet):
                 "principal": "authenticated",
                 "effect": "allow",
                 "condition": [
-                    "has_model_or_obj_perms:container.change_containerdistribution",
+                    "has_namespace_or_obj_perms:container.change_containerdistribution",
                     "has_namespace_or_obj_perms:container.view_containerdistribution",
                 ],
             },


### PR DESCRIPTION
@ipanova I don't know if using `has_model_or_obj_perms` for `container.change_containerdistribution` was intentional or not, but in case it wasn't, here's a fix.