### PR TITLE
Create and return empty blob on the fly.

### DIFF
--- a/CHANGES/8654.bugfix
+++ b/CHANGES/8654.bugfix
@@ -1,0 +1,1 @@
+Create and return empty_blob on the fly (Backported from https://pulp.plan.io/issues/8631)

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -36,6 +36,7 @@ from pulp_container.app import models, serializers
 from pulp_container.app.authorization import AuthorizationService
 from pulp_container.app.redirects import FileStorageRedirects, S3StorageRedirects
 from pulp_container.app.token_verification import TokenAuthentication, TokenPermission
+from pulp_container.constants import EMPTY_BLOB
 
 
 log = logging.getLogger(__name__)
@@ -520,6 +521,8 @@ class Blobs(RedirectsMixin, ContainerRegistryApiMixin, ViewSet):
         try:
             blob = models.Blob.objects.get(digest=pk, pk__in=repository_version.content)
         except models.Blob.DoesNotExist:
+            if pk == EMPTY_BLOB:
+                return redirects.redirect_to_content_app("blobs", pk)
             raise BlobNotFound(digest=pk)
         return redirects.issue_blob_redirect(blob)
 

--- a/pulp_container/constants.py
+++ b/pulp_container/constants.py
@@ -15,3 +15,4 @@ MEDIA_TYPE = SimpleNamespace(
     REGULAR_BLOB_OCI="application/vnd.oci.image.layer.v1.tar+gzip",
     FOREIGN_BLOB_OCI="application/vnd.oci.image.layer.nondistributable.v1.tar+gzip",
 )
+EMPTY_BLOB = "sha256:a3ed95caeb02ffe68cdd9fd84406680ae93d633cb16422d00e8a7c22955b46d4"

--- a/pulp_container/tests/functional/api/test_pull_content.py
+++ b/pulp_container/tests/functional/api/test_pull_content.py
@@ -16,6 +16,7 @@ from pulp_smash.pulp3.utils import (
 )
 
 from pulp_container.tests.functional.utils import (
+    TOKEN_AUTH_DISABLED,
     core_client,
     gen_container_client,
     gen_container_remote,
@@ -29,7 +30,7 @@ from pulp_container.tests.functional.constants import (
     REPO_UPSTREAM_NAME,
     REPO_UPSTREAM_TAG,
 )
-from pulp_container.constants import MEDIA_TYPE
+from pulp_container.constants import EMPTY_BLOB, MEDIA_TYPE
 
 from pulpcore.client.pulp_container import (
     ContainerContainerDistribution,
@@ -175,6 +176,37 @@ class PullContentTestCase(unittest.TestCase):
         # a manifest without signatures
         computed_digest = hashlib.sha256(manifest_string).hexdigest()
         self.assertEqual(computed_digest, header_digest, "The manifest digests are not equal")
+
+    def test_create_empty_blob_on_the_fly(self):
+        """
+        Test if empty blob getscreated and served on the fly.
+        """
+        blob_path = "/v2/{}/blobs/{}".format(self.distribution_with_repo.base_path, EMPTY_BLOB)
+        empty_blob_url = urljoin(self.cfg.get_base_url(), blob_path)
+
+        if TOKEN_AUTH_DISABLED:
+            auth = ()
+        else:
+            with self.assertRaises(requests.HTTPError) as cm:
+                requests.get(empty_blob_url).raise_for_status()
+
+            content_response = cm.exception.response
+            self.assertEqual(content_response.status_code, 401)
+
+            authenticate_header = content_response.headers["Www-Authenticate"]
+            queries = AuthenticationHeaderQueries(authenticate_header)
+            content_response = requests.get(
+                queries.realm, params={"service": queries.service, "scope": queries.scope}
+            )
+            content_response.raise_for_status()
+            auth = BearerTokenAuth(content_response.json()["token"])
+        content_response = requests.get(empty_blob_url, auth=auth)
+        content_response.raise_for_status()
+        # calculate digest of the payload
+        digest = hashlib.sha256(content_response.content).hexdigest()
+        # compare with the digest returned in the response header
+        header_digest = content_response.headers["docker-content-digest"].split(":")[1]
+        self.assertEqual(digest, header_digest)
 
     def test_pull_image_from_repository(self):
         """Verify that a client can pull the image from Pulp.

--- a/pulp_container/tests/functional/utils.py
+++ b/pulp_container/tests/functional/utils.py
@@ -8,7 +8,7 @@ from unittest import SkipTest
 from time import sleep
 from tempfile import NamedTemporaryFile
 
-from pulp_smash import selectors, config
+from pulp_smash import cli, config, selectors, utils
 from pulp_smash.pulp3.utils import (
     gen_remote,
     gen_repo,
@@ -35,7 +35,10 @@ from pulpcore.client.pulp_container import (
 )
 
 cfg = config.get_config()
+cli_client = cli.Client(cfg)
 configuration = cfg.get_bindings_config()
+
+TOKEN_AUTH_DISABLED = utils.get_pulp_setting(cli_client, "TOKEN_AUTH_DISABLED")
 
 
 def gen_container_client():


### PR DESCRIPTION
backports #8631
closes #8654

(cherry picked from commit c16e10f7d7e680821f48a5c55f2818cb55383b7f)