### PR TITLE
Fixed "connection already closed" error in the Registry handler.

### DIFF
--- a/CHANGES/8685.bugfix
+++ b/CHANGES/8685.bugfix
@@ -1,0 +1,1 @@
+Fixed "connection already closed" error in the Registry handler (Backported from https://pulp.plan.io/issues/8672).

--- a/pulp_container/app/registry.py
+++ b/pulp_container/app/registry.py
@@ -97,6 +97,8 @@ class Registry(Handler):
                 streamed back to the client.
 
         """
+        self._reset_db_connection()
+
         path = request.match_info["path"]
         tag_name = request.match_info["tag_name"]
         distribution = self._match_distribution(path)
@@ -203,6 +205,8 @@ class Registry(Handler):
         """
         Return a response to the "GET" action.
         """
+        self._reset_db_connection()
+
         path = request.match_info["path"]
         digest = "sha256:{digest}".format(digest=request.match_info["digest"])
         distribution = self._match_distribution(path)


### PR DESCRIPTION
backports #8672
closes #8685

(cherry picked from commit 756432fac6e0b188ff80b715ae33509f25103d48)