### PR TITLE
No wait in Throttled

### DIFF
--- a/CHANGES/8703.bugfix
+++ b/CHANGES/8703.bugfix
@@ -1,0 +1,1 @@
+Do not suggest a time to wait on 429 responses. This allows clients to decide to play nice and increase backoff times (Backported from #8576).

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -659,7 +659,7 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
                 blob = models.Blob.objects.get(digest=digest)
                 return BlobResponse(blob, path, 201, request)
             elif task.state in ["waiting", "running"]:
-                raise Throttled(wait=5)
+                raise Throttled()
             else:
                 task.delete()
                 raise Exception("Failed.")
@@ -716,7 +716,7 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
                 else:
                     task.delete()
                     raise Exception("Failed.")
-            raise Throttled(wait=5)
+            raise Throttled()
         else:
             raise Exception("The digest did not match")
 
@@ -870,7 +870,7 @@ class Manifests(RedirectsMixin, ContainerRegistryApiMixin, ViewSet):
             else:
                 task.delete()
                 raise Exception("Failed.")
-        raise Throttled(wait=5)
+        raise Throttled()
 
     def receive_artifact(self, chunk):
         """Handles assembling of Manifest as it's being uploaded."""


### PR DESCRIPTION
Stop to tell the client to wait for a specific amount. This way, well
behaved clients will increase their waiting time exponentially while
retrying.

closes #8703
backports #8576

(cherry picked from commit 3796cab986a8ca2892d70802279ab01896018fbe)