### PR TITLE
Fix links to container API

### DIFF
--- a/CHANGES/8125.doc
+++ b/CHANGES/8125.doc
@@ -1,0 +1,1 @@
+Fixed broken links to API guide

--- a/docs/workflows/host.rst
+++ b/docs/workflows/host.rst
@@ -1,6 +1,6 @@
 .. _host:
 
-Host and Consume a Container Repository 
+Host and Consume a Container Repository
 =======================================
 
 This section assumes that you have a repository with content in it. To do this, see the
@@ -33,7 +33,7 @@ Response:
 
 
 
-Reference: `Container Distribution Usage <../restapi.html#tag/distributions>`_
+Reference: `Container Distribution Usage <../restapi.html#tag/Distributions:-Container>`_
 
 Pull and run an image from Pulp
 -------------------------------

--- a/docs/workflows/manage-content.rst
+++ b/docs/workflows/manage-content.rst
@@ -40,7 +40,7 @@ a user is trying to tag an image with a same name but with a different
 digest, the tag associated with the old manifest is going to be
 eliminated in a new repository version.
 
-Reference: `Container Tagging Usage <../restapi.html#tag/container:-tag>`_
+Reference: `Container Tagging Usage <../restapi.html#tag/Content:-Tags>`_
 
 .. _untagging-workflow:
 
@@ -58,7 +58,7 @@ corresponding tag. The removed tag however still persists in a database.
 When a client tries to untag an image that was already untagged, a new
 repository version is created as well.
 
-Reference: `Container Untagging Usage <../restapi.html#tag/container:-untag>`_
+Reference: `Container Untagging Usage <../restapi.html#operation/repositories_container_container_push_untag>`_
 
 .. _recursive-add:
 
@@ -143,7 +143,7 @@ New Repository Version::
    Directly adding a manifest that happens to be tagged in another repo
    will **not** include its tags.
 
-Reference: `Container Recursive Add Usage <../restapi.html#tag/container:-recursive-add>`_
+Reference: `Container Recursive Add Usage <../restapi.html#operation/repositories_container_container_add>`_
 
 .. _recursive-remove:
 
@@ -210,7 +210,7 @@ New Repository Version::
 
    Users can remove all content from the repo by specifying '*' in the content_units
 
-Reference: `Container Recursive Remove Usage <../restapi.html#tag/container:-recursive-remove>`_
+Reference: `Container Recursive Remove Usage <../restapi.html#operation/repositories_container_container_remove>`_
 
 .. _tag-copy:
 
@@ -280,7 +280,7 @@ New Repository Version::
        "number": 1
    }
 
-Reference: `Container Copy Tags Usage <../restapi.html#operation/container_tags_copy_create>`_
+Reference: `Container Copy Tags Usage <../restapi.html#operation/repositories_container_container_copy_tags>`_
 
 .. _manifest-copy:
 
@@ -332,4 +332,4 @@ New Repository Version::
        "number": 2
    }
 
-Reference: `Container Copy Manifests Usage <../restapi.html#operation/container_manifests_copy_create>`_
+Reference: `Container Copy Manifests Usage <../restapi.html#operation/repositories_container_container_copy_manifests>`_

--- a/docs/workflows/sync.rst
+++ b/docs/workflows/sync.rst
@@ -23,8 +23,8 @@ Repository GET Response::
        "name": "codzo"
    }
 
-Reference (pulpcore): `Repository API Usage
-<https://docs.pulpproject.org/restapi.html#tag/repositories>`_
+Reference: `Container Repository API Usage
+<../restapi.html#tag/Repositories:-Container>`_
 
 .. _create-remote:
 
@@ -67,7 +67,7 @@ Remote GET Response::
    matches defined criteria by leveraging wildcards.
 
 
-Reference: `Container Remote Usage <../restapi.html#tag/remotes>`_
+Reference: `Container Remote Usage <../restapi.html#tag/Remotes:-Container>`_
 
 .. _sync-repository:
 
@@ -91,7 +91,7 @@ sync with. You are telling pulp to fetch content from the remote and add to the 
    It is not posible to push content to a repository that has been used to mirror content.
 
 
-Reference: `Container Sync Usage <../restapi.html#operation/remotes_container_container_sync>`_
+Reference: `Container Sync Usage <../restapi.html#operation/repositories_container_container_sync>`_
 
 
 .. _versioned-repo-created:
@@ -147,5 +147,5 @@ Repository Version GET Response (when complete):
        "number": 1
    }
 
-Reference (pulpcore): `Repository Version API Usage
-<https://docs.pulpproject.org/restapi.html#operation/repositories_versions_read>`_
+Reference: `Container Repository Version API Usage
+<../restapi.html#operation/repositories_container_container_list>`_


### PR DESCRIPTION
The API links in these workflows are broken. 
I addressed what is mentioned in the issue. 
I tested all the links just there, and they seem correct now, if I'm pointing to the correct place.
I can go through all the workflows as part of this but I wanted to check first: 
Is this likely to break again? Is some better solution necessary?

fixes #8125