### PR TITLE
Do not keep _static in the git repo

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -6,6 +6,7 @@ SPHINXOPTS    = -W -n
 SPHINXBUILD   = sphinx-build
 PAPER         =
 BUILDDIR      = _build
+STATIC_BUILD_DIR     = _static
 DIAGRAM_BUILD_DIR    = _diagrams
 DIAGRAM_SOURCE_DIR    = diagrams_src
 PULP_URL      = "http://localhost:24817"
@@ -56,7 +57,8 @@ else
 endif
 
 html:
-	curl -o _static/api.json "$(PULP_URL)/pulp/api/v3/docs/api.json?plugin=pulp_container"
+	mkdir -p $(STATIC_BUILD_DIR)
+	curl --fail -o $(STATIC_BUILD_DIR)/api.json "$(PULP_URL)/pulp/api/v3/docs/api.json?plugin=pulp_container&include_html=1"
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html
 	@echo
 	@echo "Build finished. The HTML pages are in $(BUILDDIR)/html."


### PR DESCRIPTION
Ensure that _static dir is created when needed.
Remove a hack for keeping an empty directory in the git repo.

There is no problem with the current approach,
just bringing in line with the plugin template approach
to have more consistency across plugins.

[noissue]