### PR TITLE
Improved error logging on failed image push.

### DIFF
--- a/CHANGES/8888.bugfix
+++ b/CHANGES/8888.bugfix
@@ -1,0 +1,2 @@
+Improved error logging on failed image push. (Backported from https://pulp.plan.io/issues/8879).
+

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -661,8 +661,9 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
             elif task.state in ["waiting", "running"]:
                 raise Throttled()
             else:
+                error = task.error
                 task.delete()
-                raise Exception("Failed.")
+                raise Exception(str(error))
 
         chunks = UploadChunk.objects.filter(upload=upload).order_by("offset")
 
@@ -714,8 +715,9 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
                 elif task.state in ["waiting", "running"]:
                     continue
                 else:
+                    error = task.error
                     task.delete()
-                    raise Exception("Failed.")
+                    raise Exception(str(error))
             raise Throttled()
         else:
             raise Exception("The digest did not match")
@@ -868,8 +870,9 @@ class Manifests(RedirectsMixin, ContainerRegistryApiMixin, ViewSet):
             elif task.state in ["waiting", "running"]:
                 continue
             else:
+                error = task.error
                 task.delete()
-                raise Exception("Failed.")
+                raise Exception(str(error))
         raise Throttled()
 
     def receive_artifact(self, chunk):


### PR DESCRIPTION
closes #8888
backports #8879

(cherry picked from commit 98196997256da0b4af2017bddc3a7e890140d280)