### PR TITLE
Ensure banner gets added when docs are built

### DIFF
--- a/doc_requirements.txt
+++ b/doc_requirements.txt
@@ -1,2 +1,2 @@
-sphinx<1.8.0
+sphinx
 towncrier


### PR DESCRIPTION
[noissue]

When the CI goes to build the docs it installs a really outdated version of sphinx that doesn't have the feature required to add the js needed for the inserting the survey banner.