### PR TITLE
Rename NewDistributionFilter to DistributionFilter

### DIFF
--- a/pulp_container/app/viewsets.py
+++ b/pulp_container/app/viewsets.py
@@ -36,7 +36,7 @@ from pulpcore.plugin.viewsets import (
     CharInFilter,
     ContentFilter,
     ContentGuardViewSet,
-    NewDistributionFilter,
+    DistributionFilter,
     NamedModelViewSet,
     NAME_FILTER_OPTIONS,
     ReadOnlyContentViewSet,
@@ -100,7 +100,7 @@ class BlobFilter(ContentFilter):
         }
 
 
-class ContainerDistributionFilter(NewDistributionFilter):
+class ContainerDistributionFilter(DistributionFilter):
     """
     FilterSet for ContainerDistributions
     """
@@ -109,7 +109,7 @@ class ContainerDistributionFilter(NewDistributionFilter):
 
     class Meta:
         model = models.ContainerDistribution
-        fields = NewDistributionFilter.Meta.fields
+        fields = DistributionFilter.Meta.fields
 
 
 class ContainerNamespaceFilter(BaseFilterSet):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-pulpcore>=3.12.1
+pulpcore>=3.14.0
 ecdsa~=0.13.2
 pyjwkest~=1.4.0
 pyjwt[crypto]~=1.7.1


### PR DESCRIPTION
To address pulpcore 3.15 compatibility.
NewDistributionFilter was deprecated in 3.14.
DistributionFilter was added in 3.14

[noissue]