### PR TITLE
Use proxy auth credentials during sync

### DIFF
--- a/CHANGES/9065.bugfix
+++ b/CHANGES/9065.bugfix
@@ -1,0 +1,1 @@
+Use proxy auth credentials when syncing content from a Remote.

--- a/pulp_container/app/downloaders.py
+++ b/pulp_container/app/downloaders.py
@@ -58,7 +58,9 @@ class RegistryAuthHttpDownloader(HttpDownloader):
         headers.update(auth_headers)
         # aiohttps does not allow to send auth argument and auth header together
         self.session._default_auth = None
-        async with self.session.get(self.url, headers=headers, proxy=self.proxy) as response:
+        async with self.session.get(
+            self.url, headers=headers, proxy=self.proxy, proxy_auth=self.proxy_auth
+        ) as response:
             try:
                 response.raise_for_status()
             except ClientResponseError as e:
@@ -131,7 +133,11 @@ class RegistryAuthHttpDownloader(HttpDownloader):
                 basic = aiohttp.BasicAuth(self.remote.username, self.remote.password).encode()
                 headers["Authorization"] = basic
             async with self.session.get(
-                token_url, headers=headers, proxy=self.proxy, raise_for_status=True
+                token_url,
+                headers=headers,
+                proxy=self.proxy,
+                proxy_auth=self.proxy_auth,
+                raise_for_status=True,
             ) as token_response:
                 token_data = await token_response.text()
 


### PR DESCRIPTION
fixes: #9065
https://pulp.plan.io/issues/9065