### PR TITLE
Touch artifacts and content to prevent cleanup

### DIFF
--- a/CHANGES/9134.misc
+++ b/CHANGES/9134.misc
@@ -1,0 +1,1 @@
+Added touch statements to artifacts and content units where cleanup needs to be prevented.

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -680,11 +680,13 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
                 artifact.save()
             except IntegrityError:
                 artifact = Artifact.objects.get(sha256=artifact.sha256)
+                artifact.touch()
             try:
                 blob = models.Blob(digest=digest, media_type=models.MEDIA_TYPE.REGULAR_BLOB)
                 blob.save()
             except IntegrityError:
                 blob = models.Blob.objects.get(digest=digest)
+                blob.touch()
             try:
                 blob_artifact = ContentArtifact(
                     artifact=artifact, content=blob, relative_path=digest
@@ -827,6 +829,7 @@ class Manifests(RedirectsMixin, ContainerRegistryApiMixin, ViewSet):
             manifest.save()
         except IntegrityError:
             manifest = models.Manifest.objects.get(digest=manifest.digest)
+            manifest.touch()
         ca = ContentArtifact(artifact=artifact, content=manifest, relative_path=manifest.digest)
         try:
             ca.save()
@@ -846,6 +849,7 @@ class Manifests(RedirectsMixin, ContainerRegistryApiMixin, ViewSet):
             tag.save()
         except IntegrityError:
             tag = models.Tag.objects.get(name=tag.name, tagged_manifest=manifest)
+            tag.touch()
 
         tags_to_remove = models.Tag.objects.filter(
             pk__in=repository.latest_version().content.all(), name=tag
@@ -899,4 +903,5 @@ class Manifests(RedirectsMixin, ContainerRegistryApiMixin, ViewSet):
                 artifact.save()
             except IntegrityError:
                 artifact = Artifact.objects.get(sha256=artifact.sha256)
+                artifact.touch()
             return artifact

--- a/pulp_container/app/serializers.py
+++ b/pulp_container/app/serializers.py
@@ -372,6 +372,7 @@ class TagImageSerializer(TagOperationSerializer):
             manifest = models.Manifest.objects.get(
                 pk__in=new_data["latest_version"].content.all(), digest=new_data["digest"]
             )
+            manifest.touch()
         except models.Manifest.DoesNotExist:
             raise serializers.ValidationError(
                 _(
@@ -608,7 +609,9 @@ class OCIBuildImageSerializer(serializers.Serializer):
                     _("Only one of 'containerfile' and 'containerfile_artifact' may be specified.")
                 )
             data["containerfile_artifact"] = Artifact.init_and_validate(data.pop("containerfile"))
-        elif "containerfile_artifact" not in data:
+        elif "containerfile_artifact" in data:
+            data["containerfile_artifact"].touch()
+        else:
             raise serializers.ValidationError(
                 _("'containerfile' or 'containerfile_artifact' must " "be specified.")
             )
@@ -627,6 +630,7 @@ class OCIBuildImageSerializer(serializers.Serializer):
                 )
                 try:
                     artifact = artifactfield.run_validation(data=url)
+                    artifact.touch()
                     artifacts[artifact.pk] = relative_path
                 except serializers.ValidationError as e:
                     # Append the URL of missing Artifact to the error message

--- a/pulp_container/app/tasks/builder.py
+++ b/pulp_container/app/tasks/builder.py
@@ -31,6 +31,7 @@ def get_or_create_blob(layer_json, manifest, path):
     """
     try:
         blob = Blob.objects.get(digest=layer_json["digest"])
+        blob.touch()
     except Blob.DoesNotExist:
         layer_file_name = "{}{}".format(path, layer_json["digest"][7:])
         layer_artifact = Artifact.init_and_validate(layer_file_name)

--- a/pulp_container/app/tasks/sync_stages.py
+++ b/pulp_container/app/tasks/sync_stages.py
@@ -107,6 +107,7 @@ class ContainerFirstStage(Stage):
             except IntegrityError:
                 del tag.artifact_attributes["file"]
                 saved_artifact = Artifact.objects.get(**tag.artifact_attributes)
+                saved_artifact.touch()
 
             tag_name = tag.url.split("/")[-1]
             tag_dc = DeclarativeContent(Tag(name=tag_name))


### PR DESCRIPTION
This change prepares for the async orphan cleanup that is expected to
come with pulpcore 3.15.

fixes #9134