### PR TITLE
Revert "Updated code to support drf-access-policy ~=1.0.1"

### DIFF
--- a/CHANGES/9092.bugfix
+++ b/CHANGES/9092.bugfix
@@ -1,1 +1,0 @@
-Switched from ``condition`` element to ``condition_expression`` for boolean logic evaluation to support beaking changes introduced in drf-access-policy-1.0.0.

--- a/pulp_container/app/viewsets.py
+++ b/pulp_container/app/viewsets.py
@@ -1046,7 +1046,7 @@ class ContainerDistributionViewSet(DistributionViewSet):
                 "action": ["pull"],
                 "principal": "*",
                 "effect": "allow",
-                "condition_expression": [
+                "condition": [
                     "not is_private",
                 ],
             },


### PR DESCRIPTION
This reverts commit 4fb95de3681faf84554a238433cea87a04ea06cd.

This change was breaking compatibility with pulpcore 3.14. The
compatibility issue has been worked around in pulpcore 3.15, so we will
reintroduce this commit with the 3.16 compatibility release.

[noissue]