### PR TITLE
Refactor sync pipeline with content resolution

### DIFF
--- a/CHANGES/9334.bugfix
+++ b/CHANGES/9334.bugfix
@@ -1,0 +1,2 @@
+Refactor sync pipeline to fix a race condition with multiple synchronous syncs.
+(backported from #9292)

--- a/pulp_container/app/models.py
+++ b/pulp_container/app/models.py
@@ -190,6 +190,7 @@ class Tag(Content):
 
     name = models.CharField(max_length=255, db_index=True)
 
+    # TODO This should be 'null=False'.
     tagged_manifest = models.ForeignKey(
         Manifest, null=True, related_name="tagged_manifests", on_delete=models.CASCADE
     )


### PR DESCRIPTION
This will no longer create hollow tags that will be updated later, but
wait for their creation until the Manifest is in the database.

backports #9292

fixes #9334

(cherry picked from commit 7285b7ab28c652b508b03f453ffcb7c80d0923f1)