### PR TITLE
Bugfix for container clients failing to retrieve artefacts from S3 storage

### DIFF
--- a/CHANGES/9586.bugfix
+++ b/CHANGES/9586.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that caused container clients to be unable to interact with content stored on S3.

--- a/pulp_container/app/redirects.py
+++ b/pulp_container/app/redirects.py
@@ -112,7 +112,9 @@ class S3StorageRedirects(CommonRedirects):
             "ResponseContentType": return_media_type,
             "ResponseContentDisposition": f"attachment;filename={filename}",
         }
-        content_url = artifact.file.storage.url(artifact.file.name, parameters=parameters)
+        content_url = artifact.file.storage.url(
+            artifact.file.name, parameters=parameters, http_method=self.request.method
+        )
         return redirect(content_url)
 
 


### PR DESCRIPTION
Issue described [here](https://pulp.plan.io/issues/9586).