### PR TITLE
Fix 500 error when registry blobs are missing on the filesystem

### DIFF
--- a/pulp_container/app/registry.py
+++ b/pulp_container/app/registry.py
@@ -237,6 +237,9 @@ class Registry(Handler):
             raise PathNotResolved(path)
         else:
             artifact = ca.artifact
+            artifact_file = os.path.join(settings.MEDIA_ROOT, artifact.file.name)
+            if not os.path.exists(artifact_file):
+                raise PathNotResolved(path)
             if artifact:
                 return await Registry._dispatch(artifact.file, headers)
             else:


### PR DESCRIPTION
On a customer call, we were seeing errors that looked like this in `/var/log/messages`:

```
Jan 26 16:39:55 rn000052275 gunicorn[238574]: pulp [-]:  - - [26/Jan/2022:22:39:55 +0000] "HEAD /v2/ee-supported-rhel8/blobs/sha256:1e6a9467750ba441584f9678e1537abd9e3b028f063da3994befd760452196f3 HTTP/1.0" 302 0 "-" "skopeo/1.4.2-dev"
Jan 26 16:39:55 rn000052275 gunicorn[238573]: [2022-01-26 22:39:55 +0000] [238656] [ERROR] Error handling request
Jan 26 16:39:55 rn000052275 gunicorn[238573]: Traceback (most recent call last):
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib64/python3.8/site-packages/aiohttp/web_protocol.py", line 422, in _handle_request
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    resp = await self._request_handler(request)
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib64/python3.8/site-packages/aiohttp/web_app.py", line 499, in _handle
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    resp = await handler(request)
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib64/python3.8/site-packages/aiohttp/web_middlewares.py", line 119, in impl
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    return await handler(request)
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib/python3.8/site-packages/pulpcore/content/authentication.py", line 35, in authenticate
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    return await handler(request)
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib/python3.8/site-packages/pulp_container/app/registry.py", line 269, in get_by_digest
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    return await Registry._dispatch(artifact.file, headers)
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib/python3.8/site-packages/pulp_container/app/registry.py", line 78, in _dispatch
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    full_headers["Content-Length"] = str(file.size)
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib/python3.8/site-packages/django/db/models/fields/files.py", line 71, in size
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    return self.storage.size(self.name)
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib/python3.8/site-packages/django/core/files/storage.py", line 334, in size
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    return os.path.getsize(self.path(name))
Jan 26 16:39:55 rn000052275 gunicorn[238573]:  File "/usr/lib64/python3.8/genericpath.py", line 50, in getsize
Jan 26 16:39:55 rn000052275 gunicorn[238573]:    return os.stat(filename).st_size
Jan 26 16:39:55 rn000052275 gunicorn[238573]: FileNotFoundError: [Errno 2] No such file or directory: '/var/lib/pulp/media/artifact/1e/6a9467750ba441584f9678e1537abd9e3b028f063da3994befd760452196f3'
Jan 26 16:39:55 rn000052275 gunicorn[238573]: [26/Jan/2022:22:39:55 +0000] "HEAD /pulp/container/ee-supported-rhel8/blobs/sha256:1e6a9467750ba441584f9678e1537abd9e3b028f063da3994befd760452196f3?
```

This happened when a new pulp server was provisioned, pointed at an existing database. I was able to reproduce the error by just nuking things under `/var/lib/pulp/media/artifact/`.

Not sure if this patch is "correct", but it does seem to resolve the issue.