### PR TITLE
Fixed null value in column "manifest_id" during sync.

### DIFF
--- a/CHANGES/537.bugfix
+++ b/CHANGES/537.bugfix
@@ -1,0 +1,1 @@
+Fixed "manifest_id" violates not-null constraint error during sync.


### PR DESCRIPTION
closes #537

(cherry picked from commit 4f85e83308310b892cad292eae117666a9856bc0)