### PR TITLE
Fixed 'NoneType' object has no attribute 'state' during image push.

### DIFF
--- a/CHANGES/542.bugfix
+++ b/CHANGES/542.bugfix
@@ -1,0 +1,1 @@
+Fixed error during container image push.

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -645,12 +645,11 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
             upload = models.Upload.objects.get(pk=pk, repository=repository)
         except models.Upload.DoesNotExist as e_upload:
             # Upload has been deleted => task has started or even finished
-            try:
-                task = Task.objects.filter(
-                    name__endswith="add_and_remove",
-                    reserved_resources_record__resource=f"upload:{pk}",
-                ).last()
-            except Task.DoesNotExist:
+            task = Task.objects.filter(
+                name__endswith="add_and_remove",
+                reserved_resources_record__resource=f"upload:{pk}",
+            ).last()
+            if not task:
                 # No upload and no task for it => the upload probably never existed
                 # return 404
                 raise e_upload


### PR DESCRIPTION
closes #542

(cherry picked from commit 508b693afdc0e0252f9350b0551dc18f7b83be5c)