### PR TITLE
Fixed url of the registry root endpoint during signature source check.

### DIFF
--- a/CHANGES/646.bugfix
+++ b/CHANGES/646.bugfix
@@ -1,0 +1,1 @@
+Fixed url of the registry root endpoint during signature source check.

--- a/pulp_container/app/tasks/sync_stages.py
+++ b/pulp_container/app/tasks/sync_stages.py
@@ -85,7 +85,7 @@ class ContainerFirstStage(Stage):
             if self.remote.sigstore:
                 return SIGNATURE_SOURCE.SIGSTORE
 
-            registry_v2_url = urljoin(self.remote.url, "v2")
+            registry_v2_url = urljoin(self.remote.url, "v2/")
             extension_check_downloader = self.remote.get_noauth_downloader(url=registry_v2_url)
             response_headers = {}
             try:


### PR DESCRIPTION
closes #646