### PR TITLE
Add validation for uploaded and synced manifests

### DIFF
--- a/CHANGES/672.feature
+++ b/CHANGES/672.feature
@@ -1,0 +1,1 @@
+Added validation for uploaded and synced manifest JSON content.

--- a/CHANGES/853.bugfix
+++ b/CHANGES/853.bugfix
@@ -1,0 +1,2 @@
+Fixed internal server errors raised when a podman client (<4.0) used invalid content types for
+manifest lists.

--- a/CHANGES/854.bugfix
+++ b/CHANGES/854.bugfix
@@ -1,0 +1,1 @@
+Fixed a misleading error message raised when a user provided an invalid manifest list.

--- a/pulp_container/app/exceptions.py
+++ b/pulp_container/app/exceptions.py
@@ -89,14 +89,14 @@ class ManifestNotFound(NotFound):
 class ManifestInvalid(ParseError):
     """Exception to render a 400 with the code 'MANIFEST_INVALID'"""
 
-    def __init__(self, digest):
+    def __init__(self, digest, reason=None):
         """Initialize the exception with the manifest digest."""
         super().__init__(
             detail={
                 "errors": [
                     {
                         "code": "MANIFEST_INVALID",
-                        "message": "manifest invalid",
+                        "message": reason or "manifest invalid",
                         "detail": {"digest": digest},
                     }
                 ]

--- a/pulp_container/constants.py
+++ b/pulp_container/constants.py
@@ -12,8 +12,12 @@ MEDIA_TYPE = SimpleNamespace(
     MANIFEST_OCI="application/vnd.oci.image.manifest.v1+json",
     INDEX_OCI="application/vnd.oci.image.index.v1+json",
     CONFIG_BLOB_OCI="application/vnd.oci.image.config.v1+json",
-    REGULAR_BLOB_OCI="application/vnd.oci.image.layer.v1.tar+gzip",
-    FOREIGN_BLOB_OCI="application/vnd.oci.image.layer.nondistributable.v1.tar+gzip",
+    REGULAR_BLOB_OCI_TAR="application/vnd.oci.image.layer.v1.tar",
+    REGULAR_BLOB_OCI_TAR_GZIP="application/vnd.oci.image.layer.v1.tar+gzip",
+    REGULAR_BLOB_OCI_TAR_ZSTD="application/vnd.oci.image.layer.v1.tar+zstd",
+    FOREIGN_BLOB_OCI_TAR="application/vnd.oci.image.layer.nondistributable.v1.tar",
+    FOREIGN_BLOB_OCI_TAR_GZIP="application/vnd.oci.image.layer.nondistributable.v1.tar+gzip",
+    FOREIGN_BLOB_OCI_TAR_ZSTD="application/vnd.oci.image.layer.nondistributable.v1.tar+zstd",
 )
 
 MANIFEST_MEDIA_TYPES = SimpleNamespace(

--- a/pulp_container/tests/unit/test_json_schemas.py
+++ b/pulp_container/tests/unit/test_json_schemas.py
@@ -6,7 +6,7 @@ from django.test import TestCase
 
 from pulp_container.app.json_schemas import SIGNATURE_SCHEMA
 
-validator = Draft7Validator(json.loads(SIGNATURE_SCHEMA))
+validator = Draft7Validator(SIGNATURE_SCHEMA)
 
 
 class TestSignatureJsonSchema(TestCase):


### PR DESCRIPTION
In this commit, a couple of validation schemas were
introduced to the sync and push workflows. Newly added
manifests or manifest lists are now being validated by
the JSON validator.

closes #854
closes #853
closes #672