### PR TITLE
Extract key_id and timestamp from raw signature packets

### DIFF
--- a/CHANGES/519.bugfix
+++ b/CHANGES/519.bugfix
@@ -1,0 +1,1 @@
+Silenced redundant GnuPG errors logged while decrypting manifest signatures.


### PR DESCRIPTION
Adding the '--skip-verify' option to the decryption workflow results in
omitting the key_id and timestamp fields in the decrypted object. In this
commit, the said fields are manually extracted from signatures.

closes #519