### PR TITLE
Fixed 404 during sync from registry.redhat.io

### DIFF
--- a/CHANGES/974.bugfix
+++ b/CHANGES/974.bugfix
@@ -1,0 +1,1 @@
+Fixed an HTTP 404 response during sync from registry.redhat.io.

--- a/pulp_container/app/downloaders.py
+++ b/pulp_container/app/downloaders.py
@@ -78,12 +78,12 @@ class RegistryAuthHttpDownloader(HttpDownloader):
 
                             self.registry_auth["bearer"] = None
                             await self.update_token(response_auth_header, this_token, repo_name)
-                        return await self._run(handle_401=False)
+                        return await self._run(handle_401=False, extra_data=extra_data)
                     elif "Basic" in response_auth_header:
                         if self.remote.username:
                             basic = aiohttp.BasicAuth(self.remote.username, self.remote.password)
                             self.registry_auth["basic"] = basic.encode()
-                        return await self._run(handle_401=False)
+                        return await self._run(handle_401=False, extra_data=extra_data)
                 else:
                     raise
             to_return = await self._handle_response(response)


### PR DESCRIPTION
Whenever a token expires a new token is requested.
    The 404 sync problem was triggered because the accept headers that
    were passed originally with the expired token were not passed to the
    re-newed token. As a result the registry was redirecting to the wrong
    schema version (schema1, which is unsupported since july 2022
    https://access.redhat.com/articles/6138332) because of absense of the
    accept headers.

closes #974