### PR TITLE
Avoid circular import when importing pulpcore.plugins

### DIFF
--- a/pulp_container/app/models.py
+++ b/pulp_container/app/models.py
@@ -25,7 +25,6 @@ from pulpcore.plugin.models import (
     Upload as CoreUpload,
 )
 from pulpcore.plugin.repo_version_utils import remove_duplicates, validate_repo_version
-from pulpcore.plugin.util import verify_signature
 
 
 from . import downloaders
@@ -431,6 +430,8 @@ class ManifestSigningService(SigningService):
             RuntimeError: If the validation has failed.
 
         """
+        from pulpcore.plugin.util import verify_signature
+
         test_manifest = {
             "schemaVersion": 2,
             "mediaType": "application/vnd.docker.distribution.manifest.v2+json",


### PR DESCRIPTION
```pytb
[galaxy@67e643fa8b19 /]$ pip list | grep pulp
pulp-ansible                    0.15.0
pulp-container                  2.14.0
pulpcore                        3.21.0
[galaxy@67e643fa8b19 /]$ django-admin shell_plus
Traceback (most recent call last):
  File "/venv/bin/django-admin", line 8, in <module>
    sys.exit(execute_from_command_line())
  File "/venv/lib64/python3.8/site-packages/django/core/management/__init__.py", line 419, in execute_from_command_line
    utility.execute()
  File "/venv/lib64/python3.8/site-packages/django/core/management/__init__.py", line 395, in execute
    django.setup()
  File "/venv/lib64/python3.8/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/venv/lib64/python3.8/site-packages/django/apps/registry.py", line 114, in populate
    app_config.import_models()
  File "/venv/lib64/python3.8/site-packages/django/apps/config.py", line 301, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1014, in _gcd_import
  File "<frozen importlib._bootstrap>", line 991, in _find_and_load
  File "<frozen importlib._bootstrap>", line 975, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 671, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 843, in exec_module
  File "<frozen importlib._bootstrap>", line 219, in _call_with_frames_removed
  File "/venv/lib64/python3.8/site-packages/pulp_container/app/models.py", line 28, in <module>
    from pulpcore.plugin.util import verify_signature
  File "/venv/lib64/python3.8/site-packages/pulpcore/plugin/util.py", line 1, in <module>
    from pulpcore.app.role_util import (  # noqa
  File "/venv/lib64/python3.8/site-packages/pulpcore/app/role_util.py", line 14, in <module>
    from pulpcore.app.models.role import GroupRole, Role, UserRole
  File "/venv/lib64/python3.8/site-packages/pulpcore/app/models/role.py", line 30, in <module>
    class UserRole(BaseModel):
  File "/venv/lib64/python3.8/site-packages/pulpcore/app/models/role.py", line 42, in UserRole
    get_user_model(), related_name="object_roles", on_delete=models.CASCADE
  File "/venv/lib64/python3.8/site-packages/django/contrib/auth/__init__.py", line 160, in get_user_model
    return django_apps.get_model(settings.AUTH_USER_MODEL, require_ready=False)
  File "/venv/lib64/python3.8/site-packages/django/apps/registry.py", line 209, in get_model
    app_config.import_models()
  File "/venv/lib64/python3.8/site-packages/django/apps/config.py", line 301, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib64/python3.8/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/app/galaxy_ng/app/models/__init__.py", line 5, in <module>
    from .collectionimport import (
  File "/app/galaxy_ng/app/models/collectionimport.py", line 6, in <module>
    from .namespace import Namespace
  File "/app/galaxy_ng/app/models/namespace.py", line 8, in <module>
    from galaxy_ng.app.access_control import mixins
  File "/app/galaxy_ng/app/access_control/mixins.py", line 7, in <module>
    from pulpcore.plugin.util import (
ImportError: cannot import name 'assign_role' from partially initialized module 'pulpcore.plugin.util' (most likely due to a circular import) (/venv/lib64/python3.8/site-packages/pulpcore/plugin/util.py)
```