### PR TITLE
Add application/octet-stream to allowed mediaTypes

### DIFF
--- a/CHANGES/1156.bugfix
+++ b/CHANGES/1156.bugfix
@@ -1,0 +1,1 @@
+Added application/octet-stream as an accepted media_type for docker config objects.

--- a/pulp_container/app/json_schemas.py
+++ b/pulp_container/app/json_schemas.py
@@ -1,4 +1,4 @@
-from pulp_container.constants import MEDIA_TYPE, SIGNATURE_TYPE
+from pulp_container.constants import BLOB_CONTENT_TYPE, MEDIA_TYPE, SIGNATURE_TYPE
 
 
 def get_descriptor_schema(
@@ -147,7 +147,7 @@ DOCKER_MANIFEST_V2_SCHEMA = {
             "properties": {
                 "mediaType": {
                     "type": "string",
-                    "enum": [MEDIA_TYPE.CONFIG_BLOB],
+                    "enum": [MEDIA_TYPE.CONFIG_BLOB, BLOB_CONTENT_TYPE],
                 },
                 "size": {"type": "number"},
                 "digest": {"type": "string"},


### PR DESCRIPTION
Without this change, sync tasks had been failing because some of the remote registries could host the config objects with an invalid media type (i.e., application/octet-stream). However, these objects can be still parsed by container clients without any errors.

closes #1156