### PR TITLE
Import deprecated functions from pulpcore.plugin.util

### DIFF
--- a/pulp_container/app/viewsets.py
+++ b/pulp_container/app/viewsets.py
@@ -15,12 +15,11 @@ from drf_spectacular.utils import extend_schema
 from rest_framework import mixins
 from rest_framework.decorators import action
 
-from pulpcore.plugin.actions import raise_for_unknown_content_units
 from pulpcore.plugin.models import RepositoryVersion
 from pulpcore.plugin.serializers import AsyncOperationResponseSerializer
 from pulpcore.plugin.models import Artifact, Content
 from pulpcore.plugin.tasking import dispatch, general_multi_delete
-from pulpcore.plugin.util import get_objects_for_user
+from pulpcore.plugin.util import extract_pk, get_objects_for_user, raise_for_unknown_content_units
 from pulpcore.plugin.viewsets import (
     AsyncUpdateMixin,
     DistributionViewSet,
@@ -708,7 +707,7 @@ class ContainerRepositoryViewSet(
 
         if "content_units" in request.data:
             for url in request.data["content_units"]:
-                add_content_units[NamedModelViewSet.extract_pk(url)] = url
+                add_content_units[extract_pk(url)] = url
 
             self.touch_content_units(add_content_units)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 # remember to also update unittest_requirements.txt when updating this file
 ecdsa>=0.14,<=0.18.0
 jsonschema>=4.4,<4.18
-pulpcore>=3.20.0.dev,<3.25
+pulpcore>=3.23,<3.25
 pyjwkest>=1.4,<=1.4.2
 pyjwt[crypto]>=2.4,<2.7


### PR DESCRIPTION
This commit fixes CI deprecation failures.

[noissue]