### PR TITLE
Revert "Return 401 instead of 403"

### DIFF
--- a/CHANGES/1254.bugfix
+++ b/CHANGES/1254.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that disallowed users to configure custom authentication classes for the token server.

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -28,7 +28,6 @@ from pulpcore.plugin.models import Artifact, ContentArtifact, Task, UploadChunk
 from pulpcore.plugin.files import PulpTemporaryUploadedFile
 from pulpcore.plugin.tasking import add_and_remove, dispatch
 from pulpcore.plugin.util import get_objects_for_user
-from rest_framework.authentication import BasicAuthentication
 from rest_framework.exceptions import (
     AuthenticationFailed,
     NotAuthenticated,
@@ -357,7 +356,6 @@ class BearerTokenView(APIView):
     """
 
     # Allow everyone to access but still value authenticated users.
-    authentication_classes = [BasicAuthentication]
     permission_classes = []
 
     def get(self, request):

--- a/pulp_container/tests/functional/api/test_token_authentication.py
+++ b/pulp_container/tests/functional/api/test_token_authentication.py
@@ -5,6 +5,7 @@ import unittest
 
 from urllib.parse import urljoin, urlparse
 import requests
+import pytest
 
 from pulp_smash import api, config, cli
 from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
@@ -139,6 +140,9 @@ class TokenAuthenticationTestCase(unittest.TestCase):
         self.assertEqual(pulled_manifest_digest, config_blob_response["digest"])
 
 
+@pytest.mark.skip(
+    reason="Skipping until the issue https://github.com/pulp/pulp_container/issues/918 is addressed"
+)
 def test_invalid_user(pulp_settings, local_registry):
     """Test if the token server correctly returns a 401 error in case of invalid credentials."""
 


### PR DESCRIPTION
This reverts commit 3979fb6ed15d1a809b03b71718341d6ba3e7124b.

closes #1254

The change disallowed users to use customized authentication classes, e.g., for managing credentials by leveraging keycloak.