### PR TITLE
Use a custom exception handler in the token server API

### DIFF
--- a/CHANGES/918.bugfix
+++ b/CHANGES/918.bugfix
@@ -1,0 +1,2 @@
+Ensured an HTTP 401 response in case a user provides invalid credentials during the login
+(e.g., via ``podman login``).

--- a/pulp_container/app/exceptions.py
+++ b/pulp_container/app/exceptions.py
@@ -1,4 +1,19 @@
-from rest_framework.exceptions import NotFound, ParseError
+from rest_framework import status, views
+from rest_framework.exceptions import (
+    AuthenticationFailed,
+    NotAuthenticated,
+    NotFound,
+    ParseError,
+)
+
+
+def unauthorized_exception_handler(exc, context):
+    response = views.exception_handler(exc, context)
+
+    if isinstance(exc, (AuthenticationFailed, NotAuthenticated)):
+        response.status_code = status.HTTP_401_UNAUTHORIZED
+
+    return response
 
 
 class RepositoryNotFound(NotFound):

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -51,6 +51,7 @@ from pulp_container.app.access_policy import RegistryAccessPolicy
 from pulp_container.app.authorization import AuthorizationService
 from pulp_container.app.cache import find_base_path_cached, RegistryApiCache
 from pulp_container.app.exceptions import (
+    unauthorized_exception_handler,
     InvalidRequest,
     RepositoryNotFound,
     RepositoryInvalid,
@@ -369,6 +370,9 @@ class BearerTokenView(APIView):
         authorization_service = AuthorizationService(self.request.user, service, scope)
         data = authorization_service.generate_token()
         return Response(data=data)
+
+    def get_exception_handler(self):
+        return unauthorized_exception_handler
 
 
 class VersionView(ContainerRegistryApiMixin, APIView):

--- a/pulp_container/tests/functional/api/test_token_authentication.py
+++ b/pulp_container/tests/functional/api/test_token_authentication.py
@@ -5,7 +5,6 @@ import unittest
 
 from urllib.parse import urljoin, urlparse
 import requests
-import pytest
 
 from pulp_smash import api, config, cli
 from pulp_smash.pulp3.bindings import delete_orphans, monitor_task
@@ -140,9 +139,6 @@ class TokenAuthenticationTestCase(unittest.TestCase):
         self.assertEqual(pulled_manifest_digest, config_blob_response["digest"])
 
 
-@pytest.mark.skip(
-    reason="Skipping until the issue https://github.com/pulp/pulp_container/issues/918 is addressed"
-)
 def test_invalid_user(token_server_url, local_registry):
     """Test if the token server correctly returns a 401 error in case of invalid credentials."""
 


### PR DESCRIPTION
closes #918

(cherry picked from commit 04e36ece729c6233d71a5efa1048a44f59df5f21)