### PR TITLE
Dispatch one task per blob mounting

### DIFF
--- a/CHANGES/1211.bugfix
+++ b/CHANGES/1211.bugfix
@@ -1,0 +1,1 @@
+Started triggering only one mount-blob task per upload after back-off.

--- a/pulp_container/app/utils.py
+++ b/pulp_container/app/utils.py
@@ -115,7 +115,7 @@ def extract_data_from_signature(signature_raw, man_digest):
     return sig_json
 
 
-def has_task_completed(dispatched_task):
+def has_task_completed(dispatched_task, wait_in_seconds=3):
     """
     Wait a couple of seconds until the task finishes its run.
 
@@ -127,7 +127,7 @@ def has_task_completed(dispatched_task):
         Throttled: If the task did not finish within a predefined timespan.
 
     """
-    for dummy in range(3):
+    for dummy in range(wait_in_seconds):
         time.sleep(1)
         task = Task.objects.get(pk=dispatched_task.pk)
         if task.state == "completed":


### PR DESCRIPTION
With this change, we check whether a blob mounting task was already dispatched to not trigger a similar task for the same content once again after back-off.

closes #1211