### PR TITLE
Defer import to avoid circular imports.

### DIFF
--- a/pulp_container/app/models.py
+++ b/pulp_container/app/models.py
@@ -25,7 +25,8 @@ from pulpcore.plugin.models import (
     Upload as CoreUpload,
 )
 from pulpcore.plugin.repo_version_utils import remove_duplicates, validate_repo_version
-from pulpcore.plugin.util import gpg_verify
+
+# from pulpcore.plugin.util import gpg_verify
 
 
 from . import downloaders
@@ -431,6 +432,9 @@ class ManifestSigningService(SigningService):
             RuntimeError: If the validation has failed.
 
         """
+
+        from pulpcore.plugin.util import gpg_verify
+
         test_manifest = {
             "schemaVersion": 2,
             "mediaType": "application/vnd.docker.distribution.manifest.v2+json",


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/venv/bin/django-admin", line 8, in <module>
    sys.exit(execute_from_command_line())
  File "/venv/lib64/python3.9/site-packages/django/core/management/__init__.py", line 442, in execute_from_command_line
    utility.execute()
  File "/venv/lib64/python3.9/site-packages/django/core/management/__init__.py", line 416, in execute
    django.setup()
  File "/venv/lib64/python3.9/site-packages/django/__init__.py", line 24, in setup
    apps.populate(settings.INSTALLED_APPS)
  File "/venv/lib64/python3.9/site-packages/django/apps/registry.py", line 116, in populate
    app_config.import_models()
  File "/venv/lib64/python3.9/site-packages/django/apps/config.py", line 269, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "<frozen importlib._bootstrap>", line 1030, in _gcd_import
  File "<frozen importlib._bootstrap>", line 1007, in _find_and_load
  File "<frozen importlib._bootstrap>", line 986, in _find_and_load_unlocked
  File "<frozen importlib._bootstrap>", line 680, in _load_unlocked
  File "<frozen importlib._bootstrap_external>", line 850, in exec_module
  File "<frozen importlib._bootstrap>", line 228, in _call_with_frames_removed
  File "/venv/lib64/python3.9/site-packages/pulp_container/app/models.py", line 28, in <module>
    from pulpcore.plugin.util import gpg_verify
  File "/venv/lib64/python3.9/site-packages/pulpcore/plugin/util.py", line 1, in <module>
    from pulpcore.app.role_util import (  # noqa
  File "/venv/lib64/python3.9/site-packages/pulpcore/app/role_util.py", line 14, in <module>
    from pulpcore.app.models.role import GroupRole, Role, UserRole
  File "/venv/lib64/python3.9/site-packages/pulpcore/app/models/role.py", line 30, in <module>
    class UserRole(BaseModel):
  File "/venv/lib64/python3.9/site-packages/pulpcore/app/models/role.py", line 44, in UserRole
    get_user_model(), related_name="object_roles", on_delete=models.CASCADE
  File "/venv/lib64/python3.9/site-packages/django/contrib/auth/__init__.py", line 170, in get_user_model
    return django_apps.get_model(settings.AUTH_USER_MODEL, require_ready=False)
  File "/venv/lib64/python3.9/site-packages/django/apps/registry.py", line 211, in get_model
    app_config.import_models()
  File "/venv/lib64/python3.9/site-packages/django/apps/config.py", line 269, in import_models
    self.models_module = import_module(models_module_name)
  File "/usr/lib64/python3.9/importlib/__init__.py", line 127, in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
  File "/app/galaxy_ng/app/models/__init__.py", line 17, in <module>
    from .container import (
  File "/app/galaxy_ng/app/models/container.py", line 11, in <module>
    container_models.ContainerDistribution,
AttributeError: partially initialized module 'pulp_container.app.models' has no attribute 'ContainerDistribution' (most likely due to a circular import)
make: *** [Makefile:108: docker/loaddata] Error 1
```