### PR TITLE
Implement flatpak index view

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -68,7 +68,7 @@ services:
 VARSYAML
 
 cat >> vars/main.yaml << VARSYAML
-pulp_settings: {"allowed_content_checksums": ["sha1", "sha224", "sha256", "sha384", "sha512"], "allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"]}
+pulp_settings: {"allowed_content_checksums": ["sha1", "sha224", "sha256", "sha384", "sha512"], "allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"], "flatpak_index": true}
 pulp_scheme: https
 
 pulp_container_tag: https
@@ -107,7 +107,7 @@ if [ "$TEST" = "azure" ]; then
       - ./azurite:/etc/pulp\
     command: "azurite-blob --blobHost 0.0.0.0 --cert /etc/pulp/azcert.pem --key /etc/pulp/azkey.pem"' vars/main.yaml
   sed -i -e '$a azure_test: true\
-pulp_scenario_settings: null\
+pulp_scenario_settings: {"flatpak_index": true}\
 ' vars/main.yaml
 fi
 

--- a/.github/workflows/scripts/post_before_script.sh
+++ b/.github/workflows/scripts/post_before_script.sh
@@ -1,0 +1,4 @@
+if [[ " ${SCENARIOS[*]} " =~ " ${TEST} " ]]; then
+  # Needed by pulp_container/tests/functional/api/test_flatpak.py:
+  cmd_prefix dnf install -yq dbus-daemon flatpak
+fi

--- a/CHANGES/1315.feature
+++ b/CHANGES/1315.feature
@@ -1,0 +1,1 @@
+Added support for Flatpak index endpoints.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,6 +28,7 @@ Features
 * Host content either `locally or on S3 <https://docs.pulpproject.org/installation/storage.html>`_
 * De-duplication of all saved content
 * Support disconnected and air-gapped environments with the Pulp Import/Export facility for container repositories
+* Support for :ref:`hosting Flatpak content in OCI format <flatpak-workflow>`
 
 Tech Preview
 ------------

--- a/docs/tech-preview.rst
+++ b/docs/tech-preview.rst
@@ -4,3 +4,4 @@ Tech previews
 The following features are currently being released as part of a tech preview:
 
 * Build an OCI image from a Containerfile
+* Support for hosting Flatpak content in OCI format.

--- a/docs/workflows/flatpak-support.rst
+++ b/docs/workflows/flatpak-support.rst
@@ -1,0 +1,64 @@
+.. _flatpak-workflow:
+
+Hosting Flatpak Content in OCI Format
+=====================================
+
+Pulp can host Flatpak application and runtime images that are distributed in OCI format.  To make
+such content discoverable, it can provide ``/index/dynamic`` and ``/index/static`` endpoints as
+specified by `the Flatpak registry index protocol
+<https://github.com/flatpak/flatpak-oci-specs/blob/main/registry-index.md>`_.  This is not enabled
+by default.  To enable it, define ``FLATPAK_INDEX = True`` in the settings file.
+
+Clients like the ``flatpak`` command-line tool or the GNOME Software application will typically
+query the ``/index/static`` endpoint, which is intended to be called repeatedly with identical query
+parameters, and whose responses are meant to be cached.  The ``/index/dynamic`` endpoint serves
+exactly the same content, but is intended for one-off requests that should not be cached.  These
+endpoints can be accessed without authentication.  They only provide information about public
+repositories.
+
+The two endpoints support a number of query parameters (``architecture``, ``tag``, ``label``, etc.),
+see the protocol specification for details.  Two notes:
+
+* Every request must include a ``label:org.flatpak.ref:exists=1`` query parameter.  This acts as a
+  marker to only report Flatpak content, and to exclude other container content that may also be
+  provided by the Pulp instance.
+
+* This implementation does not support annotations.  Including any ``annotation`` query parameters
+  will result in a 400 failure response.  Use ``label`` query parameters instead.  (Existing clients
+  like the ``flatpak`` command-line tool never issue requests including any ``annotation`` query
+  parameters.)
+
+Install a Flatpak image from Pulp
+---------------------------------
+
+This section assumes that you have created at least one public distribution in your Pulp instance
+that serves a repository containing Flatpak content.  To do this, see the general :doc:`host`
+documentation.
+
+You can for example use the ``flatpak`` `command-line tool
+<https://docs.flatpak.org/en/latest/using-flatpak.html#the-flatpak-command>`_ to set up a Flatpak
+remote (named ``pulp`` here) that references your Pulp instance:
+
+.. code:: shell
+
+  flatpak remote-add pulp oci+"$BASE_ADDR"
+
+Then, use
+
+.. code:: shell
+
+  flatpak remote-ls pulp
+
+to retrieve a list of all Flatpak applications and runtimes that your Pulp instance serves.  (This
+queries the ``/index/static`` endpoint, as explained above.)  Finally, if your Pulp instance serves
+e.g. the ``org.gnome.gedit`` application, use
+
+.. code:: shell
+
+  flatpak install pulp org.gnome.gedit
+
+to install it and run it with
+
+.. code:: shell
+
+  flatpak run org.gnome.gedit

--- a/docs/workflows/index.rst
+++ b/docs/workflows/index.rst
@@ -78,3 +78,4 @@ OCI artifact support
    cosign-support
    helm-support
    oci-artifacts
+   flatpak-support

--- a/pulp_container/app/cache.py
+++ b/pulp_container/app/cache.py
@@ -6,6 +6,7 @@ from pulp_container.app.models import ContainerDistribution
 from pulp_container.app.exceptions import RepositoryNotFound
 
 ACCEPT_HEADER_KEY = "accept_header"
+QUERY_KEY = "query"
 
 
 class RegistryCache:
@@ -72,3 +73,19 @@ def find_base_path_cached(request, cached):
         except ObjectDoesNotExist:
             raise RepositoryNotFound(name=path)
         return distro.base_path
+
+
+class FlatpakIndexStaticCache(SyncContentCache):
+    def __init__(self, expires_ttl=None, auth=None):
+        updated_keys = (QUERY_KEY,)
+        super().__init__(
+            base_key="/index/static", expires_ttl=expires_ttl, keys=updated_keys, auth=auth
+        )
+
+    def make_key(self, request):
+        """Make a key composed of the request's query."""
+        all_keys = {
+            QUERY_KEY: request.query_params.urlencode(),
+        }
+        key = ":".join(all_keys[k] for k in self.keys)
+        return key

--- a/pulp_container/app/settings.py
+++ b/pulp_container/app/settings.py
@@ -46,3 +46,5 @@ ADDITIONAL_OCI_ARTIFACT_TYPES = {
         "application/vnd.wasm.content.layer.v1+wasm",
     ],
 }
+
+FLATPAK_INDEX = False

--- a/pulp_container/app/urls.py
+++ b/pulp_container/app/urls.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.urls import include, path
 from rest_framework.routers import Route, SimpleRouter
 from pulp_container.app.registry_api import (
@@ -5,6 +6,8 @@ from pulp_container.app.registry_api import (
     Blobs,
     BlobUploads,
     CatalogView,
+    FlatpakIndexDynamicView,
+    FlatpakIndexStaticView,
     Manifests,
     Signatures,
     TagsListView,
@@ -35,3 +38,10 @@ urlpatterns = [
     path("v2/<path:path>/tags/list", TagsListView.as_view()),
     path("", include(router.urls)),
 ]
+if settings.FLATPAK_INDEX:
+    urlpatterns.extend(
+        [
+            path("index/dynamic", FlatpakIndexDynamicView.as_view()),
+            path("index/static", FlatpakIndexStaticView.as_view()),
+        ]
+    )

--- a/pulp_container/tests/functional/api/test_flatpak.py
+++ b/pulp_container/tests/functional/api/test_flatpak.py
@@ -1,0 +1,72 @@
+"""Tests that verify Flatpak support"""
+import pytest
+import subprocess
+
+from django.conf import settings
+
+from pulp_container.tests.functional.constants import REGISTRY_V2
+
+
+def test_flatpak_install(
+    add_to_cleanup,
+    registry_client,
+    local_registry,
+    container_namespace_api,
+):
+    if not settings.FLATPAK_INDEX:
+        pytest.skip("This test requires FLATPAK_INDEX to be enabled")
+
+    image_path1 = f"{REGISTRY_V2}/pulp/oci-net.fishsoup.busyboxplatform:latest"
+    registry_client.pull(image_path1)
+    local_registry.tag_and_push(image_path1, "pulptest/oci-net.fishsoup.busyboxplatform:latest")
+    image_path2 = f"{REGISTRY_V2}/pulp/oci-net.fishsoup.hello:latest"
+    registry_client.pull(image_path2)
+    local_registry.tag_and_push(image_path2, "pulptest/oci-net.fishsoup.hello:latest")
+    namespace = container_namespace_api.list(name="pulptest").results[0]
+    add_to_cleanup(container_namespace_api, namespace.pulp_href)
+
+    # Install flatpak:
+    subprocess.check_call(
+        [
+            "flatpak",
+            "--user",
+            "remote-add",
+            "pulptest",
+            "oci+" + settings.CONTENT_ORIGIN,
+        ]
+    )
+    # See <https://pagure.io/fedora-lorax-templates/c/cc1155372046baa58f9d2cc27a9e5473bf05a3fb>
+    # "lorax-embed-flatpaks.tmpl: Run the flatpak-install under dbus-run-session" for the need for
+    # dbus-run-session to avoid "error: Cannot autolaunch D-Bus without X11 $DISPLAY":
+    subprocess.check_call(
+        [
+            "dbus-run-session",
+            "flatpak",
+            "--user",
+            "install",
+            "--noninteractive",
+            "pulptest",
+            "net.fishsoup.Hello",
+        ]
+    )
+
+    # Clean up flatpak:
+    subprocess.run(
+        [
+            "flatpak",
+            "--user",
+            "uninstall",
+            "--noninteractive",
+            "net.fishsoup.Hello",
+        ]
+    )
+    subprocess.run(
+        [
+            "flatpak",
+            "--user",
+            "uninstall",
+            "--noninteractive",
+            "net.fishsoup.BusyBoxPlatform",
+        ]
+    )
+    subprocess.run(["flatpak", "--user", "remote-delete", "pulptest"])

--- a/template_config.yml
+++ b/template_config.yml
@@ -62,8 +62,14 @@ pulp_settings:
   - /tmp
   allowed_import_paths:
   - /tmp
-pulp_settings_azure: null
+  flatpak_index: true
+pulp_settings_azure:
+  flatpak_index: true
 pulp_settings_gcp: null
+# Do not enable flatpak_index for s3 for now, as it would cause
+# pulp_container/tests/functional/api/test_flatpak.py to fail due to
+# <https://gitlab.gnome.org/GNOME/libsoup/-/issues/357> "Odd 400 response with https GET 302
+# redirecting to http":
 pulp_settings_s3: null
 pulp_settings_stream: null
 pulpprojectdotorg_key_id: aa499d7938ed


### PR DESCRIPTION
This implements the protocol documented at <https://github.com/owtaylor/flagstate/blob/master/docs/protocol.md>, with the following notes:
* It does not announce any Annotations, only Labels.
* It does not announce any Lists of images, only individual Images.

Both of those simplifications are in line with how upstream flatpak indexers (e.g., <https://github.com/owtaylor/flatpak-indexer> serving <https://registry.fedoraproject.org/>) behave and with what clients actually expect and make use of.

(This fixes <https://issues.redhat.com/browse/SAT-4416> "Create a JSON index to allow installing via Flatpak client".)

closes #1315