### PR TITLE
Add test code for Flatpak support

### DIFF
--- a/.github/workflows/scripts/before_script.sh
+++ b/.github/workflows/scripts/before_script.sh
@@ -39,7 +39,7 @@ cmd_prefix bash -c "usermod -a -G wheel pulp"
 SCENARIOS=("pulp" "performance" "azure" "gcp" "s3" "stream" "generate-bindings" "lowerbounds")
 if [[ " ${SCENARIOS[*]} " =~ " ${TEST} " ]]; then
   # Many functional tests require these
-  cmd_prefix dnf install -yq lsof which
+  cmd_prefix dnf install -yq dbus-daemon flatpak lsof which
 fi
 
 if [[ "${REDIS_DISABLED:-false}" == true ]]; then

--- a/pulp_container/tests/functional/api/test_flatpak.py
+++ b/pulp_container/tests/functional/api/test_flatpak.py
@@ -1,0 +1,39 @@
+"""Tests that verify Flatpak support"""
+import subprocess
+
+from django.conf import settings
+
+
+def test_flatpak_install(
+    add_to_cleanup,
+    registry_client,
+    local_registry,
+    container_namespace_api,
+):
+    image_path1 = "registry.fedoraproject.org/f38/flatpak-kde5-runtime:latest"
+    registry_client.pull(image_path1)
+    local_registry.tag_and_push(image_path1, "pulptest/f38/flatpak-kde5-runtime:latest")
+    image_path2 = "registry.fedoraproject.org/kcolorchooser:latest"
+    registry_client.pull(image_path2)
+    local_registry.tag_and_push(image_path2, "pulptest/kcolorchooser:latest")
+    subprocess.check_call(["flatpak", "remote-add", "pulptest", "oci+" + settings.CONTENT_ORIGIN])
+    # See <https://pagure.io/fedora-lorax-templates/c/cc1155372046baa58f9d2cc27a9e5473bf05a3fb>
+    # "lorax-embed-flatpaks.tmpl: Run the flatpak-install under dbus-run-session" for the need for
+    # dbus-run-session to avoid "error: Cannot autolaunch D-Bus without X11 $DISPLAY":
+    subprocess.check_call(
+        [
+            "dbus-run-session",
+            "flatpak",
+            "install",
+            "--noninteractive",
+            "pulptest",
+            "org.kde.kcolorchooser",
+        ]
+    )
+
+    # Cleanup:
+    subprocess.run(["flatpak", "uninstall", "--noninteractive", "org.kde.kcolorchooser"])
+    subprocess.run(["flatpak", "uninstall", "--noninteractive", "org.fedoraproject.KDE5Platform"])
+    subprocess.run(["flatpak", "remote-delete", "pulptest"])
+    namespace = container_namespace_api.list(name="pulptest").results[0]
+    add_to_cleanup(container_namespace_api, namespace.pulp_href)


### PR DESCRIPTION
...following up on <https://github.com/pulp/pulp_container/pull/1301> "Implement flatpak index view".

TODO:
* For one, while `registry.fedoraproject.org/kcolorchooser:latest` is rather small (an `org.flatpak.download-size` of 77097 for `app/org.kde.kcolorchooser/x86_64/stable`), its runtime `registry.fedoraproject.org/f38/flatpak-kde5-runtime:latest` is rather large (an `org.flatpak.download-size` of 1200177442 for `runtime/org.fedoraproject.KDE5Platform/x86_64/f38`).  These should be replaced with a minimal runtime and app created just for testing purposes.  (They wouldn't even need to be executable, just need to be installable.)
* And for another, they should be pulled from `ghcr.io` rather than from `registry.fedoraproject.org` (cf. the values in `pulp_container/tests/functional/constants.py` as used by other existing tests).