### PR TITLE
Check a list of scopes when verifying tokens

### DIFF
--- a/CHANGES/1286.bugfix
+++ b/CHANGES/1286.bugfix
@@ -1,0 +1,1 @@
+Fixed a security issue that allowed users without sufficient permissions to mount blobs.

--- a/pulp_container/tests/functional/api/test_repositories_list.py
+++ b/pulp_container/tests/functional/api/test_repositories_list.py
@@ -65,10 +65,10 @@ class RepositoriesList:
         authenticate_header = content_response.headers["Www-Authenticate"]
 
         queries = AuthenticationHeaderQueries(authenticate_header)
-        self.assertEqual(queries.scope, "registry:catalog:*")
+        self.assertEqual(queries.scopes, ["registry:catalog:*"])
 
         content_response = requests.get(
-            queries.realm, params={"service": queries.service, "scope": queries.scope}, auth=auth
+            queries.realm, params={"service": queries.service, "scope": queries.scopes}, auth=auth
         )
         content_response.raise_for_status()
 

--- a/pulp_container/tests/functional/conftest.py
+++ b/pulp_container/tests/functional/conftest.py
@@ -156,8 +156,6 @@ def _local_registry(pulp_cfg, bindings_cfg, registry_client):
             if TOKEN_AUTH_DISABLED:
                 auth = basic_auth
             else:
-                extended_scope = kwargs.pop("scope", None)
-
                 with pytest.raises(requests.HTTPError):
                     response = requests.request(method, url, auth=basic_auth, **kwargs)
                     response.raise_for_status()
@@ -166,13 +164,9 @@ def _local_registry(pulp_cfg, bindings_cfg, registry_client):
                 authenticate_header = response.headers["WWW-Authenticate"]
                 queries = AuthenticationHeaderQueries(authenticate_header)
 
-                scopes = [queries.scope]
-                if extended_scope:
-                    scopes.append(extended_scope)
-
                 content_response = requests.get(
                     queries.realm,
-                    params={"service": queries.service, "scope": scopes},
+                    params={"service": queries.service, "scope": queries.scopes},
                     auth=basic_auth,
                 )
                 content_response.raise_for_status()

--- a/pulp_container/tests/functional/utils.py
+++ b/pulp_container/tests/functional/utils.py
@@ -220,11 +220,16 @@ class AuthenticationHeaderQueries:
         The scope is not provided by the token server because we are accessing the endpoint from
         the root.
         """
+        self.scopes = []
+
         if not authenticate_header.lower().startswith("bearer "):
             raise Exception(f"Authentication header has wrong format.\n{authenticate_header}")
         for item in authenticate_header[7:].split(","):
             key, value = item.split("=")
-            setattr(self, key, value.strip('"'))
+            if key == "scope":
+                self.scopes.append(value.strip('"'))
+            else:
+                setattr(self, key, value.strip('"'))
 
 
 skip_if = partial(selectors.skip_if, exc=SkipTest)
@@ -257,7 +262,7 @@ def get_auth_for_url(registry_endpoint_url, auth=None):
         authenticate_header = response.headers["WWW-Authenticate"]
         queries = AuthenticationHeaderQueries(authenticate_header)
         content_response = requests.get(
-            queries.realm, params={"service": queries.service, "scope": queries.scope}, auth=auth
+            queries.realm, params={"service": queries.service, "scope": queries.scopes}, auth=auth
         )
         content_response.raise_for_status()
         token = content_response.json()["token"]


### PR DESCRIPTION
Before this commit, the registry checked one scope, ignoring other scopes that could relate to blob mounting operations. Due to that, users without sufficient permissions could mount blobs from other users unauthorized.

closes #1286