### PR TITLE
Check a list of scopes when verifying tokens

### DIFF
--- a/CHANGES/1286.bugfix
+++ b/CHANGES/1286.bugfix
@@ -1,0 +1,1 @@
+Fixed a security issue that allowed users without sufficient permissions to mount blobs.

--- a/pulp_container/tests/functional/api/test_rbac_repo_versions.py
+++ b/pulp_container/tests/functional/api/test_rbac_repo_versions.py
@@ -201,8 +201,11 @@ def test_cross_repository_blob_mount(
     container_distribution_api,
     container_namespace_api,
     container_blob_api,
+    gen_object_with_cleanup,
 ):
     """Test that users can cross mount blobs from different repositories."""
+    if TOKEN_AUTH_DISABLED:
+        pytest.skip("Cannot test blob mounting without token authentication.")
 
     source_repo = utils.uuid4()
     dest_repo = utils.uuid4()
@@ -213,6 +216,9 @@ def test_cross_repository_blob_mount(
     repository = container_push_repository_api.list(name=source_repo).results[0]
     blobs = container_blob_api.list(repository_version=repository.latest_version_href).results
     distribution = container_distribution_api.list(name=source_repo).results[0]
+    monitor_task(
+        container_distribution_api.partial_update(distribution.pulp_href, {"private": True}).task
+    )
 
     # Cleanup
     add_to_cleanup(container_namespace_api, distribution.namespace)
@@ -242,29 +248,42 @@ def test_cross_repository_blob_mount(
     except ValueError:
         pass
 
-    if not TOKEN_AUTH_DISABLED:
-        user_consumer = gen_user(
-            object_roles=[("container.containernamespace_consumer", distribution.namespace)]
-        )
-        user_collaborator = gen_user(
-            object_roles=[("container.containernamespace_collaborator", distribution.namespace)]
-        )
-        user_helpless = gen_user()
+    user_consumer = gen_user(
+        object_roles=[("container.containernamespace_consumer", distribution.namespace)]
+    )
+    user_collaborator = gen_user(
+        object_roles=[("container.containernamespace_collaborator", distribution.namespace)]
+    )
+    user_helpless = gen_user()
 
-        # Test if a user with pull permission, but not push permission, is not able to mount.
-        with user_consumer:
-            content_response, _ = mount_blob(blobs[0], source_repo, dest_repo)
-            assert content_response.status_code == 401
+    # Test if a user with pull permission, but not push permission, is not able to mount.
+    with user_consumer:
+        content_response, _ = mount_blob(blobs[0], source_repo, dest_repo)
+        assert content_response.status_code == 401
 
-        # Test if a collaborator cannot mount content outside of his scope.
-        with user_collaborator:
-            content_response, _ = mount_blob(blobs[0], source_repo, dest_repo)
-            assert content_response.status_code == 401
+    # Test if a collaborator cannot mount content outside his scope.
+    with user_collaborator:
+        content_response, _ = mount_blob(blobs[0], source_repo, dest_repo)
+        assert content_response.status_code == 401
 
-        # Test if an anonymous user with no permissions is not able to mount.
-        with user_helpless:
-            content_response, _ = mount_blob(blobs[0], source_repo, dest_repo)
-            assert content_response.status_code == 401
+    # Test if an anonymous user with no permissions is not able to mount.
+    with user_helpless:
+        content_response, _ = mount_blob(blobs[0], source_repo, dest_repo)
+        assert content_response.status_code == 401
+
+    # Test if an owner of another namespace cannot utilize the blob mounting because of
+    # insufficient permissions
+    dest_tester_namespace = utils.uuid4()
+    tester_namespace = gen_object_with_cleanup(
+        container_namespace_api, {"name": dest_tester_namespace}
+    )
+    tester_owner = gen_user(
+        object_roles=[("container.containernamespace_owner", tester_namespace.pulp_href)]
+    )
+    with tester_owner:
+        local_registry.tag_and_push(image_path, f"{tester_namespace.name}/test:manifest_a")
+        content_response, auth = mount_blob(blobs[0], source_repo, f"{dest_tester_namespace}/test")
+        assert content_response.status_code == 401
 
 
 @pytest.fixture
@@ -273,9 +292,7 @@ def mount_blob(local_registry, container_distribution_api, container_namespace_a
 
     def _mount_blob(blob, source, dest):
         mount_path = f"/v2/{dest}/blobs/uploads/?from={source}&mount={blob.digest}"
-        response, auth = local_registry.get_response(
-            "POST", mount_path, scope=f"repository:{source}:pull"
-        )
+        response, auth = local_registry.get_response("POST", mount_path)
 
         if response.status_code == 201:
             distribution = container_distribution_api.list(name=dest).results[0]

--- a/pulp_container/tests/functional/api/test_repositories_list.py
+++ b/pulp_container/tests/functional/api/test_repositories_list.py
@@ -65,10 +65,10 @@ class RepositoriesList:
         authenticate_header = content_response.headers["Www-Authenticate"]
 
         queries = AuthenticationHeaderQueries(authenticate_header)
-        self.assertEqual(queries.scope, "registry:catalog:*")
+        self.assertEqual(queries.scopes, ["registry:catalog:*"])
 
         content_response = requests.get(
-            queries.realm, params={"service": queries.service, "scope": queries.scope}, auth=auth
+            queries.realm, params={"service": queries.service, "scope": queries.scopes}, auth=auth
         )
         content_response.raise_for_status()
 

--- a/pulp_container/tests/functional/conftest.py
+++ b/pulp_container/tests/functional/conftest.py
@@ -77,8 +77,6 @@ def _local_registry(pulp_cfg, bindings_cfg, registry_client):
             if TOKEN_AUTH_DISABLED:
                 auth = basic_auth
             else:
-                extended_scope = kwargs.pop("scope", None)
-
                 with pytest.raises(requests.HTTPError):
                     response = requests.request(method, url, auth=basic_auth, **kwargs)
                     response.raise_for_status()
@@ -87,13 +85,9 @@ def _local_registry(pulp_cfg, bindings_cfg, registry_client):
                 authenticate_header = response.headers["WWW-Authenticate"]
                 queries = AuthenticationHeaderQueries(authenticate_header)
 
-                scopes = [queries.scope]
-                if extended_scope:
-                    scopes.append(extended_scope)
-
                 content_response = requests.get(
                     queries.realm,
-                    params={"service": queries.service, "scope": scopes},
+                    params={"service": queries.service, "scope": queries.scopes},
                     auth=basic_auth,
                 )
                 content_response.raise_for_status()


### PR DESCRIPTION
Before this commit, the registry checked one scope, ignoring other scopes that could relate to blob mounting operations. Due to that, users without sufficient permissions could mount blobs from other users unauthorized.

closes #1286

(cherry picked from commit 6658b7e3d432cc426edf08892d38ed0d27b06692)