### PR TITLE
Fix lint errors in type checking

### DIFF
--- a/pulp_container/app/global_access_conditions.py
+++ b/pulp_container/app/global_access_conditions.py
@@ -20,14 +20,14 @@ def has_namespace_obj_perms(request, view, action, permission):
         obj = Repository.objects.get(pk=view.kwargs["repository_pk"]).cast()
     else:
         obj = view.get_object()
-    if type(obj) == models.ContainerDistribution:
+    if type(obj) is models.ContainerDistribution:
         namespace = obj.namespace
         return request.user.has_perm(permission, namespace)
-    elif type(obj) == models.ContainerPushRepository:
+    elif type(obj) is models.ContainerPushRepository:
         for dist in obj.distributions.all():
             if request.user.has_perm(permission, dist.cast().namespace):
                 return True
-    elif type(obj) == models.ContainerPushRepositoryVersion:
+    elif type(obj) is models.ContainerPushRepositoryVersion:
         for dist in obj.repository.distributions.all():
             if request.user.has_perm(permission, dist.cast().namespace):
                 return True


### PR DESCRIPTION
Resolves the following:
./pulp_container/app/global_access_conditions.py:23:8: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()` ./pulp_container/app/global_access_conditions.py:26:10: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()` ./pulp_container/app/global_access_conditions.py:30:10: E721 do not compare types, for exact checks use `is` / `is not`, for instance checks use `isinstance()` Error: Process completed with exit code 1.

[noissue]