### PR TITLE
Use the old pulp-ci-centos:https image with updated service files 

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -71,7 +71,7 @@ cat >> vars/main.yaml << VARSYAML
 pulp_settings: {"allowed_content_checksums": ["sha1", "sha224", "sha256", "sha384", "sha512"], "allowed_export_paths": ["/tmp"], "allowed_import_paths": ["/tmp"], "flatpak_index": true}
 pulp_scheme: https
 
-pulp_container_tag: https
+pulp_container_tag: https-pulp_container-ci
 
 VARSYAML
 


### PR DESCRIPTION
This is a temporary workaround that makes the CI green once again. The referenced image uses the pulp-ci-centos:https base image. On top of it, there are layers that contain updated service files which allows us to properly run pulpcore-api and pulpcore-content services.

We will revert the commit once we will be able to resolve the execution of nested containers.

ref https://github.com/pulp/pulpcore/commit/4def68e1f1bd4ffcae5352ee9d6ff7404759a19e#diff-15df6aebb457ef62acf7707d2032bf15dc24646d040d1bf2f892929263ce570dR16

ref https://github.com/pulp/pulp-oci-images/issues/540

[noissue]