### PR TITLE
Test if a manifest references an artifact when syncing

### DIFF
--- a/CHANGES/1400.bugfix
+++ b/CHANGES/1400.bugfix
@@ -1,0 +1,1 @@
+Fixed re-sync failures after reclaiming disk space.

--- a/pulp_container/app/tasks/sync_stages.py
+++ b/pulp_container/app/tasks/sync_stages.py
@@ -95,7 +95,7 @@ class ContainerFirstStage(Stage):
 
         if digest and (
             manifest := await Manifest.objects.prefetch_related("contentartifact_set")
-            .filter(digest=digest)
+            .filter(digest=digest, _artifacts__isnull=False)
             .afirst()
         ):
             saved_artifact = await manifest._artifacts.aget()
@@ -481,7 +481,7 @@ class ContainerFirstStage(Stage):
 
         if (
             manifest := await Manifest.objects.prefetch_related("contentartifact_set")
-            .filter(digest=digest)
+            .filter(digest=digest, _artifacts__isnull=False)
             .afirst()
         ):
             saved_artifact = await manifest._artifacts.aget()

--- a/pulp_container/tests/functional/api/test_sync.py
+++ b/pulp_container/tests/functional/api/test_sync.py
@@ -50,6 +50,19 @@ def test_basic_sync(container_repo, container_remote, container_repository_api, 
     assert repository.latest_version_href == latest_version_href
 
 
+def test_sync_reclaim_resync(
+    container_repo,
+    container_remote,
+    container_sync,
+    monitor_task,
+    repositories_reclaim_space_api_client,
+):
+    """Check if re-syncing the content after the reclamation ends with no error."""
+    container_sync(container_repo, container_remote)
+    monitor_task(repositories_reclaim_space_api_client.reclaim({"repo_hrefs": ["*"]}).task)
+    container_sync(container_repo, container_remote)
+
+
 @pytest.mark.parallel
 def test_sync_invalid_url(synced_container_repository_factory):
     with pytest.raises(PulpTaskError) as ctx:


### PR DESCRIPTION
The filter now ensures that the file of a manifest will be downloaded when no referencing artifact exists.

closes #1400