### PR TITLE
Pin the pytest dependency

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,3 +1,3 @@
 pulp-smash @ git+https://github.com/pulp/pulp-smash.git
-pytest
+pytest<8
 python-gnupg

--- a/lint_requirements.txt
+++ b/lint_requirements.txt
@@ -6,7 +6,7 @@
 # For more info visit https://github.com/pulp/plugin_template
 
 # python packages handy for developers, but not required by pulp
-black
+black==23.12.1
 check-manifest
 flake8
 flake8-black


### PR DESCRIPTION
A recent upgrade of the pytest package to 8.0.0 led to errors in our CI. 

This should fix the following error: PermissionError: [Errno 13] Permission denied: '/lost+found/__init__.py'

[noissue]