### PR TITLE
Remove the optional "kid" parameter

### DIFF
--- a/CHANGES/1485.removal
+++ b/CHANGES/1485.removal
@@ -1,0 +1,3 @@
+Removed the optional "kid" parameter stored inside the signatures' payload generated during
+docker manifest v2 schema 1 conversion. This change also removes the ``ecdsa`` dependency,
+which is vulnerable to Minevra timing attacks.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-ecdsa>=0.14,<=0.18.0
 jsonschema>=4.4,<4.19
 pulpcore>=3.25.0,<3.40
 pyjwkest>=1.4,<=1.4.2


### PR DESCRIPTION
This removes the key identifier stored in the JWK's header in the manifest v2 schema 1 signatures' payload.

The "kid" parameter is optional in JWK. This parameter might be also considered irrelevant because the key pair for ECDSA is generated each time the conversion from schema 2 to schema 1 happens. So, clients cannot verify the origin of the signature with the fingerprint/kid because the public key is created on the fly and then immediately trashed.

Ref: https://www.rfc-editor.org/rfc/rfc7517#section-4.5
Ref: https://docker-docs.uclv.cu/registry/spec/manifest-v2-1/

closes #1485

(cherry picked from commit 59e06e591bd3e621401d83f417fd3fa2ecadbf0a)