### PR TITLE
Flatpak delta manifests support

### DIFF
--- a/CHANGES/1495.feature
+++ b/CHANGES/1495.feature
@@ -1,0 +1,1 @@
+Added Flatpak deltas to the defaultly supported OCI media types.

--- a/pulp_container/app/settings.py
+++ b/pulp_container/app/settings.py
@@ -45,6 +45,10 @@ ADDITIONAL_OCI_ARTIFACT_TYPES = {
     "application/vnd.wasm.config.v1+json": [
         "application/vnd.wasm.content.layer.v1+wasm",
     ],
+    # delta manifest
+    "application/vnd.redhat.delta.config.v1+json": [
+        "application/vnd.tar-diff",
+    ],
 }
 
 FLATPAK_INDEX = False


### PR DESCRIPTION
Added Flatpak deltas to the defaultly supported OCI media types.

closes #1495