### PR TITLE
fix: add leading / for specific location in snippet for nginx.conf

### DIFF
--- a/pulp_container/app/webserver_snippets/nginx.conf
+++ b/pulp_container/app/webserver_snippets/nginx.conf
@@ -9,7 +9,7 @@ location /v2/ {
     client_max_body_size 0;
 }
 
-location extensions/v2/ {
+location /extensions/v2/ {
     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
     proxy_set_header X-Forwarded-Proto $scheme;
     proxy_set_header Host $http_host;


### PR DESCRIPTION
This PR adds leading `/` to `location extensions/v2/` in snippet for `nginx.conf`.

Sorry if my understanding is incorrect and this is intended.
The file has not been updated in over two years, but perhaps there is a `/` missing. In [apache.conf](https://github.com/pulp/pulp_container/blob/9c0919fcd09bd0c4d156959cbbcf1e3b8d49a46a/pulp_container/app/webserver_snippets/apache.conf#L4-L5), there is a leading `/`.

https://github.com/pulp/pulp_container/blob/9c0919fcd09bd0c4d156959cbbcf1e3b8d49a46a/pulp_container/app/webserver_snippets/apache.conf#L4-L5

Perhaps this has not been any actual issues before, since directive for `location extensions/v2` is usually exactly the same as the `location /` and request to `/extensions/v2` is handled `location /`.