### PR TITLE
Pass certs and tls config when checking for signsture extentions during

### DIFF
--- a/CHANGES/1552.bugfix
+++ b/CHANGES/1552.bugfix
@@ -1,0 +1,1 @@
+Fixed sync failure due to ignored certs during registry signature extentions API check.

--- a/pulp_container/app/downloaders.py
+++ b/pulp_container/app/downloaders.py
@@ -1,13 +1,11 @@
 import aiohttp
 import asyncio
 import json
-import ssl
 import re
 
 from aiohttp.client_exceptions import ClientResponseError
 from collections import namedtuple
 from logging import getLogger
-from multidict import MultiDict
 from urllib import parse
 
 from pulpcore.plugin.download import DownloaderFactory, HttpDownloader
@@ -215,43 +213,6 @@ class NoAuthDownloaderFactory(DownloaderFactory):
     """
     A downloader factory without any preset auth configuration, TLS or basic auth.
     """
-
-    def _make_aiohttp_session_from_remote(self):
-        """
-        Same as DownloaderFactory._make_aiohttp_session_from_remote, excluding TLS configuration.
-
-        Returns:
-            :class:`aiohttp.ClientSession`
-
-        """
-        tcp_conn_opts = {"force_close": True}
-
-        if not self._remote.tls_validation:
-            sslcontext = ssl.create_default_context()
-            sslcontext.check_hostname = False
-            sslcontext.verify_mode = ssl.CERT_NONE
-            tcp_conn_opts["ssl_context"] = sslcontext
-
-        headers = MultiDict({"User-Agent": NoAuthDownloaderFactory.user_agent()})
-        if self._remote.headers is not None:
-            for header_dict in self._remote.headers:
-                user_agent_header = header_dict.pop("User-Agent", None)
-                if user_agent_header:
-                    headers["User-Agent"] = f"{headers['User-Agent']}, {user_agent_header}"
-                headers.extend(header_dict)
-
-        conn = aiohttp.TCPConnector(**tcp_conn_opts)
-        total = self._remote.total_timeout
-        sock_connect = self._remote.sock_connect_timeout
-        sock_read = self._remote.sock_read_timeout
-        connect = self._remote.connect_timeout
-
-        timeout = aiohttp.ClientTimeout(
-            total=total, sock_connect=sock_connect, sock_read=sock_read, connect=connect
-        )
-        return aiohttp.ClientSession(
-            connector=conn, timeout=timeout, headers=headers, requote_redirect_url=False
-        )
 
     def _http_or_https(self, download_class, url, **kwargs):
         """


### PR DESCRIPTION
sync

[noissue]

In sync we are checking whether the remot registry implrementations signsture extentions API. We need to pass respective remote tls and certs config if they were provided, hence no need to override core's ``_make_aiohttp_session_from_remote`` and use it directly from core.

We do not need to pass auth since we care only about response headers that we check.

```bash
{"traceback": "  File "/usr/lib/python3.9/site-packages/pulpcore/tasking/pulpcore_worker.py", line 450, in _perform_task
    result = func(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/pulp_container/app/tasks/synchronize.py", line 41, in synchronize
    return dv.create()
  File "/usr/lib/python3.9/site-packages/pulpcore/plugin/stages/declarative_version.py", line 161, in create
    loop.run_until_complete(pipeline)
  File "/usr/lib64/python3.9/asyncio/base_events.py", line 647, in run_until_complete
    return future.result()
  File "/usr/lib/python3.9/site-packages/pulpcore/plugin/stages/api.py", line 225, in create_pipeline
    await asyncio.gather(*futures)
  File "/usr/lib/python3.9/site-packages/pulpcore/plugin/stages/api.py", line 43, in __call__
    await self.run()
  File "/usr/lib/python3.9/site-packages/pulp_container/app/tasks/sync_stages.py", line 81, in run
    signature_source = await self.get_signature_source()
  File "/usr/lib/python3.9/site-packages/pulp_container/app/tasks/sync_stages.py", line 221, in get_signature_source
    result = await extension_check_downloader.run()
  File "/usr/lib/python3.9/site-packages/pulpcore/download/http.py", line 273, in run
    return await download_wrapper()
  File "/usr/lib/python3.9/site-packages/backoff/_async.py", line 151, in retry
    ret = await target(*args, **kwargs)
  File "/usr/lib/python3.9/site-packages/pulpcore/download/http.py", line 258, in download_wrapper
    return await self._run(extra_data=extra_data)
  File "/usr/lib/python3.9/site-packages/pulpcore/download/http.py", line 291, in _run
    async with self.session.get(
  File "/usr/lib64/python3.9/site-packages/aiohttp/client.py", line 1141, in __aenter__
    self._resp = await self._coro
  File "/usr/lib64/python3.9/site-packages/aiohttp/client.py", line 536, in _request
    conn = await self._connector.connect(
  File "/usr/lib64/python3.9/site-packages/aiohttp/connector.py", line 540, in connect
    proto = await self._create_connection(req, traces, timeout)
  File "/usr/lib64/python3.9/site-packages/aiohttp/connector.py", line 901, in _create_connection
    _, proto = await self._create_direct_connection(req, traces, timeout)
  File "/usr/lib64/python3.9/site-packages/aiohttp/connector.py", line 1206, in _create_direct_connection
    raise last_exc
  File "/usr/lib64/python3.9/site-packages/aiohttp/connector.py", line 1175, in _create_direct_connection
    transp, proto = await self._wrap_create_connection(
  File "/usr/lib64/python3.9/site-packages/aiohttp/connector.py", line 982, in _wrap_create_connection
    raise ClientConnectorCertificateError(req.connection_key, exc) from exc
", "description": "Cannot connect to host registry.tts-trax.com:443 ssl:True [SSLCertVerificationError: (1, '[SSL: CERTIFICATE_VERIFY_FAILED] certificate verify failed: unable to get local issuer certificate (_ssl.c:1129)')]"}