### PR TITLE
Check if the Authorization header for Basic Authentication is valid

### DIFF
--- a/CHANGES/1577.bugfix
+++ b/CHANGES/1577.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug that disallowed users from leveraging the remote authentication.


### PR DESCRIPTION
If the header is not valid, DRF returns None when calling the
authenticate() method. This can cause troubles when users are
leveraging the remote authentication because Pulp thinks they
are anonymous users. In the end, authorized users cannot
push or pull content from Pulp. This affects only admin users
in scenarios where the token authentication is disabled.

closes #1577