### PR TITLE
Stream artifacts from content-app if using non-local filesystem storage

### DIFF
--- a/CHANGES/1493.bugfix
+++ b/CHANGES/1493.bugfix
@@ -1,0 +1,2 @@
+Fixed a bug that caused intermittent failures during the pull-through caching when using non-local
+filesystem storage.

--- a/pulp_container/app/registry.py
+++ b/pulp_container/app/registry.py
@@ -88,10 +88,8 @@ class Registry(Handler):
             if not os.path.exists(path):
                 raise Exception("Expected path '{}' is not found".format(path))
             return web.FileResponse(path, headers=full_headers)
-        elif not settings.REDIRECT_TO_OBJECT_STORAGE:
-            return ArtifactResponse(artifact=artifact, headers=headers)
         else:
-            raise NotImplementedError("Redirecting to this storage is not implemented.")
+            return ArtifactResponse(artifact=artifact, headers=headers)
 
     @RegistryContentCache(
         base_key=lambda req, cac: Registry.find_base_path_cached(req, cac),


### PR DESCRIPTION
This commit removes the check against `REDIRECT_TO_OBJECT_STORAGE` from the Registry handler that caused Pulp to stream content only when a user opted for it. Now, the content is always streamed from content-app when using non-local filesystem storage.

closes #1493