### PR TITLE
Remove backward compatibility for manifest with artifact

### DIFF
--- a/CHANGES/1621.bugfix
+++ b/CHANGES/1621.bugfix
@@ -1,0 +1,1 @@
+Removed backward compatibility support for manifests which store their data inside an artifact.

--- a/pulp_container/app/downloaders.py
+++ b/pulp_container/app/downloaders.py
@@ -10,8 +10,6 @@ from urllib import parse
 
 from pulpcore.plugin.download import DownloaderFactory, HttpDownloader
 
-from pulp_container.constants import V2_ACCEPT_HEADERS
-
 log = getLogger(__name__)
 
 HeadResult = namedtuple(
@@ -53,11 +51,7 @@ class RegistryAuthHttpDownloader(HttpDownloader):
             handle_401(bool): If true, catch 401, request a new token and retry.
 
         """
-        # manifests are header sensitive, blobs do not care
-        # these accept headers are going to be sent with every request to ensure downloader
-        # can download manifests, namely in the repair core task
-        # FIXME this can be rolledback after https://github.com/pulp/pulp_container/issues/1288
-        headers = V2_ACCEPT_HEADERS
+        headers = {}
         repo_name = None
         if extra_data is not None:
             headers = extra_data.get("headers", headers)

--- a/pulp_container/app/redirects.py
+++ b/pulp_container/app/redirects.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import redirect
-from django.http import Http404
 
 from pulp_container.app.exceptions import ManifestNotFound
 from pulp_container.app.utils import get_accepted_media_types
@@ -90,47 +89,6 @@ class S3StorageRedirects(CommonRedirects):
             artifact.file.name, parameters=parameters, http_method=self.request.method
         )
         return redirect(content_url)
-
-    # TODO: BACKWARD COMPATIBILITY - remove after fully migrating to artifactless manifests
-    def redirect_to_artifact(self, content_name, manifest, manifest_media_type):
-        """
-        Search for the passed manifest's artifact and issue a redirect.
-        """
-        try:
-            artifact = manifest._artifacts.get()
-        except ObjectDoesNotExist:
-            raise Http404(f"An artifact for '{content_name}' was not found")
-
-        return self.redirect_to_object_storage(artifact, manifest_media_type)
-
-    def issue_tag_redirect(self, tag):
-        """
-        Issue a redirect if an accepted media type requires it or return not found if manifest
-        version is not supported.
-        """
-        if tag.tagged_manifest.data:
-            return super().issue_tag_redirect(tag)
-
-        manifest_media_type = tag.tagged_manifest.media_type
-        if manifest_media_type == MEDIA_TYPE.MANIFEST_V1:
-            return self.redirect_to_artifact(
-                tag.name, tag.tagged_manifest, MEDIA_TYPE.MANIFEST_V1_SIGNED
-            )
-        elif manifest_media_type in get_accepted_media_types(self.request.headers):
-            return self.redirect_to_artifact(tag.name, tag.tagged_manifest, manifest_media_type)
-        else:
-            raise ManifestNotFound(reference=tag.name)
-
-    def issue_manifest_redirect(self, manifest):
-        """
-        Directly redirect to an associated manifest's artifact.
-        """
-        if manifest.data:
-            return super().issue_manifest_redirect(manifest)
-
-        return self.redirect_to_artifact(manifest.digest, manifest, manifest.media_type)
-
-    # END OF BACKWARD COMPATIBILITY
 
 
 class AzureStorageRedirects(S3StorageRedirects):

--- a/pulp_container/app/registry.py
+++ b/pulp_container/app/registry.py
@@ -201,10 +201,6 @@ class Registry(Handler):
                 "Content-Type": return_media_type,
                 "Docker-Content-Digest": tag.tagged_manifest.digest,
             }
-            # TODO: BACKWARD COMPATIBILITY - remove after fully migrating to artifactless manifest
-            if not tag.tagged_manifest.data:
-                return await self.dispatch_tag(request, tag, response_headers)
-            # END OF BACKWARD COMPATIBILITY
             return web.Response(text=tag.tagged_manifest.data, headers=response_headers)
 
         # return what was found in case media_type is accepted header (docker, oci)
@@ -214,40 +210,10 @@ class Registry(Handler):
                 "Content-Type": return_media_type,
                 "Docker-Content-Digest": tag.tagged_manifest.digest,
             }
-            # TODO: BACKWARD COMPATIBILITY - remove after fully migrating to artifactless manifest
-            if not tag.tagged_manifest.data:
-                return await self.dispatch_tag(request, tag, response_headers)
-            # END OF BACKWARD COMPATIBILITY
             return web.Response(text=tag.tagged_manifest.data, headers=response_headers)
 
         # return 404 in case the client is requesting docker manifest v2 schema 1
         raise PathNotResolved(tag_name)
-
-    # TODO: BACKWARD COMPATIBILITY - remove after fully migrating to artifactless manifest
-    async def dispatch_tag(self, request, tag, response_headers):
-        """
-        Finds an artifact associated with a Tag and sends it to the client, otherwise tries
-        to stream it.
-
-        Args:
-            request(:class:`~aiohttp.web.Request`): The request to prepare a response for.
-            tag: Tag
-            response_headers (dict): dictionary that contains the 'Content-Type' header to send
-                with the response
-
-        Returns:
-            :class:`aiohttp.web.StreamResponse` or :class:`aiohttp.web.FileResponse`: The response
-                streamed back to the client.
-
-        """
-        try:
-            artifact = await tag.tagged_manifest._artifacts.aget()
-        except ObjectDoesNotExist:
-            ca = await sync_to_async(lambda x: x[0])(tag.tagged_manifest.contentartifact_set.all())
-            return await self._stream_content_artifact(request, web.StreamResponse(), ca)
-        else:
-            return await Registry._dispatch(artifact, response_headers)
-        # END OF BACKWARD COMPATIBILITY
 
     @RegistryContentCache(
         base_key=lambda req, cac: Registry.find_base_path_cached(req, cac),
@@ -284,16 +250,6 @@ class Registry(Handler):
                     "Content-Type": manifest.media_type,
                     "Docker-Content-Digest": manifest.digest,
                 }
-                # TODO: BACKWARD COMPATIBILITY - remove after migrating to artifactless manifest
-                if not manifest.data:
-                    if saved_artifact := await manifest._artifacts.afirst():
-                        return await Registry._dispatch(saved_artifact, headers)
-                    else:
-                        ca = await sync_to_async(lambda x: x[0])(manifest.contentartifact_set.all())
-                        return await self._stream_content_artifact(
-                            request, web.StreamResponse(), ca
-                        )
-                # END OF BACKWARD COMPATIBILITY
                 return web.Response(text=manifest.data, headers=headers)
             elif content_type == "blobs":
                 ca = await ContentArtifact.objects.select_related("artifact", "content").aget(

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -1084,7 +1084,7 @@ class Manifests(RedirectsMixin, ContainerRegistryApiMixin, ViewSet):
                 else:
                     raise ManifestNotFound(reference=pk)
 
-            return redirects.issue_manifest_redirect(manifest)
+            return Response(manifest.data)
 
     def get_content_units_to_add(self, manifest, tag):
         add_content_units = [str(tag.pk), str(manifest.pk)]


### PR DESCRIPTION
This commit removes support for manifests storing their data inside an artifact instead of using the recently introduced  Manifest.data text field.

closes #1621