### PR TITLE
Distribution API reports whether it uses HTTP/S

### DIFF
--- a/CHANGES/1213.feature
+++ b/CHANGES/1213.feature
@@ -1,0 +1,2 @@
+Distribution now reports whether the registry is using HTTP (insecure) or HTTPS (secure) via the
+new 'secure' field.

--- a/pulp_container/app/serializers.py
+++ b/pulp_container/app/serializers.py
@@ -351,6 +351,13 @@ class ContainerDistributionSerializer(DistributionSerializer, GetOrCreateSeriali
         view_name_pattern=r"remotes(-.*/.*)?-detail",
         read_only=True,
     )
+    secure = serializers.SerializerMethodField(
+        help_text="Whether the distribution is served over HTTP (insecure) or HTTPS (secure)."
+    )
+
+    def get_secure(self, obj):
+        request = self.context["request"]
+        return request.is_secure()
 
     def validate(self, data):
         """
@@ -406,6 +413,7 @@ class ContainerDistributionSerializer(DistributionSerializer, GetOrCreateSeriali
             "namespace",
             "private",
             "description",
+            "secure",
         )
 
 


### PR DESCRIPTION
Distribution now reports whether the registry is using HTTP (unsecure) or HTTPS (secure) via the new 'secure' field inside ContainerDistributionSerializer.

closes: #1213