### PR TITLE
Stop deleting tasks after uploading manifests

### DIFF
--- a/CHANGES/1602.bugfix
+++ b/CHANGES/1602.bugfix
@@ -1,0 +1,1 @@
+Tasks created after uploading manifests will now remain available for further inspection and will not be deleted.

--- a/pulp_container/app/utils.py
+++ b/pulp_container/app/utils.py
@@ -136,14 +136,11 @@ def has_task_completed(dispatched_task, wait_in_seconds=3):
         time.sleep(1)
         task = Task.objects.get(pk=dispatched_task.pk)
         if task.state == "completed":
-            task.delete()
             return True
         elif task.state in ["waiting", "running"]:
             continue
         else:
-            error = task.error
-            task.delete()
-            raise Exception(str(error))
+            raise Exception(str(task.error))
     raise Throttled()
 
 


### PR DESCRIPTION
Tasks created after uploading manifests are no longer automatically
deleted in any case.

closes: #1602