### PR TITLE
Disable token authentication for the S3 runner

### DIFF
--- a/.github/workflows/scripts/install.sh
+++ b/.github/workflows/scripts/install.sh
@@ -95,7 +95,7 @@ if [ "$TEST" = "s3" ]; then
   sed -i -e '$a s3_test: true\
 minio_access_key: "'$MINIO_ACCESS_KEY'"\
 minio_secret_key: "'$MINIO_SECRET_KEY'"\
-pulp_scenario_settings: {"flatpak_index": false}\
+pulp_scenario_settings: {"flatpak_index": false, "token_auth_disabled": true}\
 pulp_scenario_env: {}\
 ' vars/main.yaml
   export PULP_API_ROOT="/rerouted/djnd/"

--- a/CHANGES/1607.misc
+++ b/CHANGES/1607.misc
@@ -1,0 +1,1 @@
+Disabled token authentication for the S3 test runner.

--- a/pulp_container/app/settings.py
+++ b/pulp_container/app/settings.py
@@ -3,6 +3,7 @@ DRF_ACCESS_POLICY = {
     "reusable_conditions": ["pulp_container.app.global_access_conditions"],
 }
 
+TOKEN_AUTH_DISABLED = False
 FLATPAK_INDEX = False
 
 # The number of allowed threads to sign manifests in parallel

--- a/pulp_container/tests/functional/api/test_rbac_push_repositories.py
+++ b/pulp_container/tests/functional/api/test_rbac_push_repositories.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from django.conf import settings
+
 from pulp_smash import utils
 from pulp_smash.pulp3.bindings import monitor_task
 
@@ -19,6 +21,8 @@ def test_rbac_push_repository(
     container_push_repository_api,
 ):
     """Verify RBAC for a ContainerPushRepository."""
+    if settings.TOKEN_AUTH_DISABLED:
+        pytest.skip("RBAC cannot be tested when token authentication is disabled")
 
     namespace_name = utils.uuid4()
     repo_name = f"{namespace_name}/perms"

--- a/pulp_container/tests/functional/api/test_rbac_remotes.py
+++ b/pulp_container/tests/functional/api/test_rbac_remotes.py
@@ -3,6 +3,8 @@
 from random import choice
 import pytest
 
+from django.conf import settings
+
 from pulp_smash import utils
 from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.constants import ON_DEMAND_DOWNLOAD_POLICIES
@@ -15,6 +17,8 @@ from pulpcore.client.pulp_container.exceptions import ApiException
 @pytest.mark.parallel
 def test_rbac_remotes(gen_user, container_remote_api):
     """RBAC remotes."""
+    if settings.TOKEN_AUTH_DISABLED:
+        pytest.skip("RBAC cannot be tested when token authentication is disabled")
 
     # Setup
     user1 = gen_user(model_roles=["container.containerremote_creator"])

--- a/pulp_container/tests/functional/api/test_rbac_repo_content.py
+++ b/pulp_container/tests/functional/api/test_rbac_repo_content.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from django.conf import settings
+
 from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_repo
 
@@ -33,6 +35,8 @@ def test_rbac_repository_content(
     container_tag_api,
 ):
     """Assert that certain users can list and read content."""
+    if settings.TOKEN_AUTH_DISABLED:
+        pytest.skip("RBAC cannot be tested when token authentication is disabled")
 
     user_creator = gen_user(
         model_roles=[

--- a/pulp_container/tests/functional/api/test_rbac_repo_versions.py
+++ b/pulp_container/tests/functional/api/test_rbac_repo_versions.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from django.conf import settings
+
 from pulp_smash import utils
 from pulp_smash.pulp3.bindings import monitor_task
 from pulp_smash.pulp3.utils import gen_repo
@@ -28,6 +30,9 @@ def test_rbac_repository_version(
     container_manifest_api,
 ):
     """Verify RBAC for a ContainerRepositoryVersion."""
+    if settings.TOKEN_AUTH_DISABLED:
+        pytest.skip("RBAC cannot be tested when token authentication is disabled")
+
     user_creator = gen_user(
         model_roles=[
             "container.containerrepository_creator",
@@ -135,6 +140,9 @@ def test_rbac_push_repository_version(
     container_push_repository_version_api,
 ):
     """Verify RBAC for a ContainerPushRepositoryVersion."""
+    if settings.TOKEN_AUTH_DISABLED:
+        pytest.skip("RBAC cannot be tested when token authentication is disabled")
+
     try:
         # Remove namespace to start out clean
         namespace = container_namespace_api.list(name="test_push_repo").results[0]
@@ -191,7 +199,6 @@ def test_rbac_push_repository_version(
 def test_cross_repository_blob_mount(
     add_to_cleanup,
     gen_user,
-    pulp_cfg,
     registry_client,
     local_registry,
     mount_blob,

--- a/pulp_container/tests/functional/api/test_rbac_sync_repositories.py
+++ b/pulp_container/tests/functional/api/test_rbac_sync_repositories.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from django.conf import settings
+
 from pulp_smash import utils
 from pulp_smash.pulp3.bindings import monitor_task
 
@@ -11,6 +13,8 @@ from pulpcore.client.pulp_container.exceptions import ApiException
 @pytest.mark.parallel
 def test_rbac_sync_repositories(gen_user, container_repository_api):
     """RBAC sync repositories."""
+    if settings.TOKEN_AUTH_DISABLED:
+        pytest.skip("RBAC cannot be tested when token authentication is disabled")
 
     user1 = gen_user(model_roles=["container.containerrepository_creator"])
     user2 = gen_user(model_roles=["container.containerrepository_viewer"])

--- a/template_config.yml
+++ b/template_config.yml
@@ -64,6 +64,7 @@ pulp_settings_azure:
 pulp_settings_gcp: null
 pulp_settings_s3:
   flatpak_index: false
+  token_auth_disabled: true
 pydocstyle: true
 release_email: pulp-infra@redhat.com
 release_user: pulpbot


### PR DESCRIPTION
This change might help us identify errors in scenarios where the token authentication is disabled (e.g., Katello installations).

closes #1607