### PR TITLE
Sign ignores .sig, .att, .sbom

### DIFF
--- a/CHANGES/1347.bugfix
+++ b/CHANGES/1347.bugfix
@@ -1,0 +1,2 @@
+The pulp signing task that produces atomic type signature no longer signs cosign signatures,
+attestations and sboms (images that end with .sig, .att, or .sbom), and ignores them instead.


### PR DESCRIPTION
The signing tasks no longer signs cosign signatures, attestations and sboms (images that end with .sigg, .att, or .sbom) and ignores them instead.

closes #1347