### PR TITLE
Include `application/octet-stream` in the accept headers to be able to

### DIFF
--- a/pulp_container/app/downloaders.py
+++ b/pulp_container/app/downloaders.py
@@ -51,6 +51,10 @@ class RegistryAuthHttpDownloader(HttpDownloader):
         # can download manifests, namely in the repair core task
         # FIXME this can be rolledback after https://github.com/pulp/pulp_container/issues/1288
         headers = V2_ACCEPT_HEADERS
+        # Usually webservers ignore accept headers for blob endpoint
+        # However, some webservers when serving blobs need to have explicitly specified octet-stream
+        # in the accept headers
+        headers["Accept"] = headers["Accept"] + ",application/octet-stream"
         repo_name = None
         if extra_data is not None:
             headers = extra_data.get("headers", headers)


### PR DESCRIPTION
download content from OSP undercloud registry.

More info https://issues.redhat.com/browse/SAT-25848 [noissue]