### PR TITLE
Return all catalog repos when token-auth disabled

### DIFF
--- a/CHANGES/1651.bugfix
+++ b/CHANGES/1651.bugfix
@@ -1,0 +1,2 @@
+Modified the `_catalog` endpoint to allow non-authed users to see all repos in catalog
+(private and public) when token-auth is disabled.

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -519,6 +519,9 @@ class CatalogView(ContainerRegistryApiMixin, ListAPIView):
         distribution_permission = "container.pull_containerdistribution"
         namespace_permission = "container.namespace_pull_containerdistribution"
 
+        if settings.get("TOKEN_AUTH_DISABLED", False):
+            return queryset
+
         public_repositories = queryset.filter(private=False)
         repositories_by_distribution = get_objects_for_user(
             self.request.user, distribution_permission, queryset

--- a/pulp_container/tests/functional/api/test_repositories_list.py
+++ b/pulp_container/tests/functional/api/test_repositories_list.py
@@ -172,6 +172,14 @@ class RepositoriesListWithPermissionsTestCase(RepositoriesList, unittest.TestCas
             ]
         )
 
+        cls.repositories_names_sorted = sorted(
+            [
+                cls.distribution1.base_path,
+                cls.distribution2.base_path,
+                cls.distribution3.base_path,
+            ]
+        )
+
     @classmethod
     def tearDownClass(cls):
         """Clean generated resources."""
@@ -192,26 +200,26 @@ class RepositoriesListWithPermissionsTestCase(RepositoriesList, unittest.TestCas
         """Check if the user can see only public repositories."""
         auth = (self.user_none["username"], self.user_none["password"])
         repositories = self.get_listed_repositories(auth)
-        self.assertEqual(repositories.json(), {"repositories": [self.distribution3.base_path]})
+        if TOKEN_AUTH_DISABLED:
+            self.assertEqual(repositories.json(), {"repositories": self.repositories_names_sorted})
+        else:
+            self.assertEqual(repositories.json(), {"repositories": [self.distribution3.base_path]})
 
-    @unittest.skipIf(TOKEN_AUTH_DISABLED, "Token authentication is not enabled")
     def test_all_user(self):
         """Check if the user can see all repositories."""
         auth = (self.user_all["username"], self.user_all["password"])
         repositories = self.get_listed_repositories(auth)
-        repositories_names = sorted(
-            [
-                self.distribution1.base_path,
-                self.distribution2.base_path,
-                self.distribution3.base_path,
-            ]
-        )
-        self.assertEqual(repositories.json(), {"repositories": repositories_names})
+        self.assertEqual(repositories.json(), {"repositories": self.repositories_names_sorted})
 
-    @unittest.skipIf(TOKEN_AUTH_DISABLED, "Token authentication is not enabled")
     def test_only_dist1_user(self):
         """Check if the user can see all public repositories, but not all private repositories."""
         auth = (self.user_only_dist1["username"], self.user_only_dist1["password"])
         repositories = self.get_listed_repositories(auth)
-        repositories_names = sorted([self.distribution1.base_path, self.distribution3.base_path])
-        self.assertEqual(repositories.json(), {"repositories": repositories_names})
+
+        if TOKEN_AUTH_DISABLED:
+            self.assertEqual(repositories.json(), {"repositories": self.repositories_names_sorted})
+        else:
+            repositories_names = sorted(
+                [self.distribution1.base_path, self.distribution3.base_path]
+            )
+            self.assertEqual(repositories.json(), {"repositories": repositories_names})


### PR DESCRIPTION
With token-auth disabled, allow non-authed users to see all repos (public and private) in catalog.

closes: #1651