### PR TITLE
Validate settings before running Pulp instance

### DIFF
--- a/CHANGES/1550.bugfix
+++ b/CHANGES/1550.bugfix
@@ -1,0 +1,2 @@
+Pulp Container specific settings are now properly validated during the deployment checks of a Pulp
+instance.

--- a/pulp_container/app/__init__.py
+++ b/pulp_container/app/__init__.py
@@ -11,3 +11,4 @@ class PulpContainerPluginAppConfig(PulpPluginAppConfig):
 
     def ready(self):
         super().ready()
+        from . import checks

--- a/pulp_container/app/checks.py
+++ b/pulp_container/app/checks.py
@@ -1,0 +1,46 @@
+from django.conf import settings
+from django.core.checks import Error as CheckError, register
+
+
+@register(deploy=True)
+def container_settings_check(app_configs, **kwargs):
+    errors = []
+
+    # Other checks only apply if token auth is enabled
+    if str(getattr(settings, "TOKEN_AUTH_DISABLED", False)).lower() == "true":
+        return errors
+
+    if getattr(settings, "TOKEN_SERVER", None) is None:
+        errors.append(
+            CheckError(
+                "TOKEN_SERVER is a required setting that has to be configured when token"
+                " authentification is enabled",
+                id="pulp_container.E001",
+            ),
+        )
+    if getattr(settings, "TOKEN_SIGNATURE_ALGORITHM", None) is None:
+        errors.append(
+            CheckError(
+                "TOKEN_SIGNATURE_ALGORITHM is a required setting that has to be configured when"
+                " token authentification is enabled",
+                id="pulp_container.E001",
+            )
+        )
+    if getattr(settings, "PUBLIC_KEY_PATH", None) is None:
+        errors.append(
+            CheckError(
+                "PUBLIC_KEY_PATH is a required setting that has to be configured when token"
+                " authentification is enabled",
+                id="pulp_container.E001",
+            )
+        )
+    if getattr(settings, "PRIVATE_KEY_PATH", None) is None:
+        errors.append(
+            CheckError(
+                "PRIVATE_KEY_PATH is a required setting that has to be configured when token"
+                " authentification is enabled",
+                id="pulp_container.E001",
+            )
+        )
+
+    return errors


### PR DESCRIPTION
When token authentization is enabled, 4 additional variables have to be set. The state of these variables is now checked, while properly informing the user, instead of relying on exceptions raised later during the instance's run.

closes #1550