### PR TITLE
Fix container remote upstream name option

### DIFF
--- a/staging_docs/user/tutorials/01-sync-and-host.md
+++ b/staging_docs/user/tutorials/01-sync-and-host.md
@@ -23,7 +23,7 @@ including `quay`, `google container registry`, or even another instance of Pulp.
     Container plugin supports both Docker and OCI media types.
 
 ```bash
-pulp container remote create --name foo --url "https://registry-1.docker.io" --upstream_name=pulp/test-fixture-1
+pulp container remote create --name foo --url "https://registry-1.docker.io" --upstream-name=pulp/test-fixture-1
 ```
 
 !!! note


### PR DESCRIPTION
The example code to create a container remote contains an argument that is incorrect:

> Error: No such option: --upstream_name (Possible options: --upstream-name, --username)

This commit modifies the underscore in the argument to a hyphen. That resolves the "No such option" error.