### PR TITLE
 Do not assert on a specific error message

### DIFF
--- a/pulp_container/tests/functional/api/test_sync.py
+++ b/pulp_container/tests/functional/api/test_sync.py
@@ -97,10 +97,8 @@ def test_sync_reclaim_resync(
 
 @pytest.mark.parallel
 def test_sync_invalid_url(synced_container_repository_factory):
-    with pytest.raises(PulpTaskError) as ctx:
+    with pytest.raises(PulpTaskError):
         synced_container_repository_factory(url="http://i-am-an-invalid-url.com/invalid/")
-
-    assert "[Name or service not known]" in ctx.value.task.error["description"]
 
 
 @pytest.mark.parallel


### PR DESCRIPTION
Once an upstream library changes its behaviour, we may observe
different error messages depending on the context.

This change fixes the following error:
> assert "[Name or service not known]"
	in ctx.value.task.error["description"]
E AssertionError: assert '[Name or service not known]'
	in 'Cannot connect to host i-am-an-invalid-url.com:80 ssl:default [None]'

[noissue]