### PR TITLE
Add a check for pull-through remote removal

### DIFF
--- a/CHANGES/1729.feature
+++ b/CHANGES/1729.feature
@@ -1,0 +1,2 @@
+Added an informational message to alert users that removing a remote pull-through associated with
+a distribution may lead to problems when trying to pull non-cached content.

--- a/docs/admin/guides/pull-through-caching.md
+++ b/docs/admin/guides/pull-through-caching.md
@@ -45,6 +45,12 @@ ensures a more reliable container deployment system in production environments.
     Pulp API endpoints. The repositories are read-only and public by default.
 
 
+!!! info
+
+    Removing a pull-through remote associated to a distribution may result in errors when attempting
+    to retrieve content not yet cached in Pulp.
+
+
 ### Filtering the repositories
 
 It is possible to use the includes/excludes fields to set a list of upstream repositories that Pulp


### PR DESCRIPTION
If a pull-through remote is linked with a distribution, warn users that removing it can cause problems to pull non-cached content.

closes: #1729