### PR TITLE
Fix Any serializer type regression breaking Ruby bindings

### DIFF
--- a/CHANGES/+fix-any-type.bugfix
+++ b/CHANGES/+fix-any-type.bugfix
@@ -1,0 +1,2 @@
+Fixed the JSONField specification so it doesn't break ruby bindings.
+See context [here](https://github.com/pulp/pulp_rpm/issues/3639).

--- a/pulp_container/app/fields.py
+++ b/pulp_container/app/fields.py
@@ -1,0 +1,12 @@
+from drf_spectacular.utils import extend_schema_field
+from drf_spectacular.types import OpenApiTypes
+from rest_framework import serializers
+
+
+@extend_schema_field(OpenApiTypes.OBJECT)
+class JSONObjectField(serializers.JSONField):
+    """A drf JSONField override to force openapi schema to use 'object' type.
+
+    Not strictly correct, but we relied on that for a long time.
+    See: https://github.com/tfranzel/drf-spectacular/issues/1095
+    """

--- a/pulp_container/app/serializers.py
+++ b/pulp_container/app/serializers.py
@@ -30,7 +30,7 @@ from pulpcore.plugin.serializers import (
     ValidateFieldsMixin,
 )
 
-from pulp_container.app import models
+from pulp_container.app import models, fields
 from pulp_container.constants import SIGNATURE_TYPE
 
 VALID_SIGNATURE_NAME_REGEX = r"^sha256:[0-9a-f]{64}@[0-9a-f]{32}$"
@@ -84,11 +84,11 @@ class ManifestSerializer(NoArtifactContentSerializer):
         queryset=models.Blob.objects.all(),
     )
 
-    annotations = serializers.JSONField(
+    annotations = fields.JSONObjectField(
         read_only=True,
         help_text=_("Property that contains arbitrary metadata stored inside the image manifest."),
     )
-    labels = serializers.JSONField(
+    labels = fields.JSONObjectField(
         read_only=True,
         help_text=_("Property describing metadata stored inside the image configuration"),
     )


### PR DESCRIPTION
See https://github.com/pulp/pulp_rpm/issues/3639

(cherry picked from commit 5cc3da77f939b296fe544d262e6140c89760524b)