### PR TITLE
Django storages config deprecation (1/2)

### DIFF
--- a/pulp_container/app/registry.py
+++ b/pulp_container/app/registry.py
@@ -83,7 +83,7 @@ class Registry(Handler):
         full_headers["Docker-Content-Digest"] = headers["Docker-Content-Digest"]
         full_headers["Docker-Distribution-API-Version"] = "registry/2.0"
 
-        if settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem":
+        if settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem":
             file = artifact.file
             path = os.path.join(settings.MEDIA_ROOT, file.name)
             if not os.path.exists(path):

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -966,13 +966,16 @@ class RedirectsMixin:
         super().__init__(*args, **kwargs)
 
         if (
-            settings.DEFAULT_FILE_STORAGE == "pulpcore.app.models.storage.FileSystem"
+            settings.STORAGES["default"]["BACKEND"] == "pulpcore.app.models.storage.FileSystem"
             or not settings.REDIRECT_TO_OBJECT_STORAGE
         ):
             self.redirects_class = FileStorageRedirects
-        elif settings.DEFAULT_FILE_STORAGE == "storages.backends.s3boto3.S3Boto3Storage":
+        elif settings.STORAGES["default"]["BACKEND"] == "storages.backends.s3boto3.S3Boto3Storage":
             self.redirects_class = S3StorageRedirects
-        elif settings.DEFAULT_FILE_STORAGE == "storages.backends.azure_storage.AzureStorage":
+        elif (
+            settings.STORAGES["default"]["BACKEND"]
+            == "storages.backends.azure_storage.AzureStorage"
+        ):
             self.redirects_class = AzureStorageRedirects
         else:
             raise NotImplementedError()

--- a/pulp_container/app/tasks/sign.py
+++ b/pulp_container/app/tasks/sign.py
@@ -106,7 +106,7 @@ async def create_signature(manifest, reference, signing_service):
         if not manifest.data:
             # TODO: BACKWARD COMPATIBILITY - remove after fully migrating to artifactless manifest
             artifact = await manifest._artifacts.aget()
-            if settings.DEFAULT_FILE_STORAGE != "pulpcore.app.models.storage.FileSystem":
+            if settings.STORAGES["default"]["BACKEND"] != "pulpcore.app.models.storage.FileSystem":
                 async with tempfile.NamedTemporaryFile(dir=".", mode="wb", delete=False) as tf:
                     await tf.write(await sync_to_async(artifact.file.read)())
                     await tf.flush()


### PR DESCRIPTION
This PR:

- [x] Replaces legacy with new django storage settings
- [x] Settings on signal-handler (not required)

See #1888 
