### PR TITLE
[PULP-255] Remove backward compatibility for manifest with artifact

### DIFF
--- a/CHANGES/1621.misc
+++ b/CHANGES/1621.misc
@@ -1,0 +1,1 @@
+Removed backward compatibility support for manifests which store their data inside an artifact.

--- a/pulp_container/app/downloaders.py
+++ b/pulp_container/app/downloaders.py
@@ -10,8 +10,6 @@ from urllib import parse
 
 from pulpcore.plugin.download import DownloaderFactory, HttpDownloader
 
-from pulp_container.constants import V2_ACCEPT_HEADERS
-
 log = getLogger(__name__)
 
 HeadResult = namedtuple(
@@ -53,11 +51,7 @@ class RegistryAuthHttpDownloader(HttpDownloader):
             handle_401(bool): If true, catch 401, request a new token and retry.
 
         """
-        # manifests are header sensitive, blobs do not care
-        # these accept headers are going to be sent with every request to ensure downloader
-        # can download manifests, namely in the repair core task
-        # FIXME this can be rolledback after https://github.com/pulp/pulp_container/issues/1288
-        headers = V2_ACCEPT_HEADERS
+        headers = {}
         repo_name = None
         if extra_data is not None:
             headers = extra_data.get("headers", headers)

--- a/pulp_container/app/redirects.py
+++ b/pulp_container/app/redirects.py
@@ -1,7 +1,6 @@
 from django.conf import settings
 from django.core.exceptions import ObjectDoesNotExist
 from django.shortcuts import redirect
-from django.http import Http404
 from urllib.parse import urljoin
 
 from pulp_container.app.exceptions import ManifestNotFound
@@ -100,47 +99,6 @@ class S3StorageRedirects(CommonRedirects):
             artifact.file.name, parameters=parameters, http_method=self.request.method
         )
         return redirect(content_url)
-
-    # TODO: BACKWARD COMPATIBILITY - remove after fully migrating to artifactless manifests
-    def redirect_to_artifact(self, content_name, manifest, manifest_media_type):
-        """
-        Search for the passed manifest's artifact and issue a redirect.
-        """
-        try:
-            artifact = manifest._artifacts.get()
-        except ObjectDoesNotExist:
-            raise Http404(f"An artifact for '{content_name}' was not found")
-
-        return self.redirect_to_object_storage(artifact, manifest_media_type)
-
-    def issue_tag_redirect(self, tag):
-        """
-        Issue a redirect if an accepted media type requires it or return not found if manifest
-        version is not supported.
-        """
-        if tag.tagged_manifest.data:
-            return super().issue_tag_redirect(tag)
-
-        manifest_media_type = tag.tagged_manifest.media_type
-        if manifest_media_type == MEDIA_TYPE.MANIFEST_V1:
-            return self.redirect_to_artifact(
-                tag.name, tag.tagged_manifest, MEDIA_TYPE.MANIFEST_V1_SIGNED
-            )
-        elif manifest_media_type in get_accepted_media_types(self.request.headers):
-            return self.redirect_to_artifact(tag.name, tag.tagged_manifest, manifest_media_type)
-        else:
-            raise ManifestNotFound(reference=tag.name)
-
-    def issue_manifest_redirect(self, manifest):
-        """
-        Directly redirect to an associated manifest's artifact.
-        """
-        if manifest.data:
-            return super().issue_manifest_redirect(manifest)
-
-        return self.redirect_to_artifact(manifest.digest, manifest, manifest.media_type)
-
-    # END OF BACKWARD COMPATIBILITY
 
 
 class AzureStorageRedirects(S3StorageRedirects):


### PR DESCRIPTION
This commit removes support for manifests storing their data inside an artifact instead of using the recently introduced  Manifest.data text field.

closes #1621