### PR TITLE
Fix 500 error when using flatpak with reclaimed content [PULP-262]

### DIFF
--- a/CHANGES/1887.bugfix
+++ b/CHANGES/1887.bugfix
@@ -1,0 +1,1 @@
+Fixed flatpak index returning 500 when Manifest content was on_demand or had been reclaimed.

--- a/pulp_container/tests/functional/api/test_flatpak.py
+++ b/pulp_container/tests/functional/api/test_flatpak.py
@@ -3,39 +3,10 @@
 import pytest
 import subprocess
 
-from django.conf import settings
-
 from pulp_container.tests.functional.constants import REGISTRY_V2
 
 
-def test_flatpak_install(
-    add_to_cleanup,
-    registry_client,
-    local_registry,
-    container_namespace_api,
-    container_push_repository_api,
-    container_tag_api,
-    container_manifest_api,
-):
-    if not settings.FLATPAK_INDEX:
-        pytest.skip("This test requires FLATPAK_INDEX to be enabled")
-
-    image_path1 = f"{REGISTRY_V2}/pulp/oci-net.fishsoup.busyboxplatform:latest"
-    registry_client.pull(image_path1)
-    local_registry.tag_and_push(image_path1, "pulptest/oci-net.fishsoup.busyboxplatform:latest")
-    image_path2 = f"{REGISTRY_V2}/pulp/oci-net.fishsoup.hello:latest"
-    registry_client.pull(image_path2)
-    local_registry.tag_and_push(image_path2, "pulptest/oci-net.fishsoup.hello:latest")
-    namespace = container_namespace_api.list(name="pulptest").results[0]
-    add_to_cleanup(container_namespace_api, namespace.pulp_href)
-
-    repo = container_push_repository_api.list(name="pulptest/oci-net.fishsoup.hello").results[0]
-    tag = container_tag_api.list(repository_version=repo.latest_version_href).results[0]
-    manifest = container_manifest_api.read(tag.tagged_manifest)
-
-    assert manifest.is_flatpak
-    assert not manifest.is_bootable
-
+def run_flatpak_commands(pulp_settings):
     # Install flatpak:
     subprocess.check_call(
         [
@@ -43,7 +14,7 @@ def test_flatpak_install(
             "--user",
             "remote-add",
             "pulptest",
-            "oci+" + settings.CONTENT_ORIGIN,
+            "oci+" + pulp_settings.CONTENT_ORIGIN,
         ]
     )
     # See <https://pagure.io/fedora-lorax-templates/c/cc1155372046baa58f9d2cc27a9e5473bf05a3fb>
@@ -81,3 +52,86 @@ def test_flatpak_install(
         ]
     )
     subprocess.run(["flatpak", "--user", "remote-delete", "pulptest"])
+
+
+def test_flatpak_install(
+    add_to_cleanup,
+    registry_client,
+    local_registry,
+    container_namespace_api,
+    container_push_repository_api,
+    container_tag_api,
+    container_manifest_api,
+    pulp_settings,
+):
+    if not pulp_settings.FLATPAK_INDEX:
+        pytest.skip("This test requires FLATPAK_INDEX to be enabled")
+
+    image_path1 = f"{REGISTRY_V2}/pulp/oci-net.fishsoup.busyboxplatform:latest"
+    registry_client.pull(image_path1)
+    local_registry.tag_and_push(image_path1, "pulptest/oci-net.fishsoup.busyboxplatform:latest")
+    image_path2 = f"{REGISTRY_V2}/pulp/oci-net.fishsoup.hello:latest"
+    registry_client.pull(image_path2)
+    local_registry.tag_and_push(image_path2, "pulptest/oci-net.fishsoup.hello:latest")
+    namespace = container_namespace_api.list(name="pulptest").results[0]
+    add_to_cleanup(container_namespace_api, namespace.pulp_href)
+
+    repo = container_push_repository_api.list(name="pulptest/oci-net.fishsoup.hello").results[0]
+    tag = container_tag_api.list(repository_version=repo.latest_version_href).results[0]
+    manifest = container_manifest_api.read(tag.tagged_manifest)
+
+    assert manifest.is_flatpak
+    assert not manifest.is_bootable
+
+    run_flatpak_commands(pulp_settings)
+
+
+def test_flatpak_on_demand(
+    container_tag_api,
+    container_manifest_api,
+    container_repository_factory,
+    container_remote_factory,
+    container_sync,
+    container_distribution_factory,
+    container_namespace_api,
+    pulpcore_bindings,
+    monitor_task,
+    add_to_cleanup,
+    pulp_settings,
+):
+    if not pulp_settings.FLATPAK_INDEX:
+        pytest.skip("This test requires FLATPAK_INDEX to be enabled")
+
+    # Set up repositories with immediate sync
+    remote1 = container_remote_factory(
+        upstream_name="pulp/oci-net.fishsoup.busyboxplatform", include_tags=["latest"]
+    )
+    remote2 = container_remote_factory(
+        upstream_name="pulp/oci-net.fishsoup.hello", include_tags=["latest"]
+    )
+    repo1 = container_repository_factory(remote=remote1.pulp_href)
+    repo2 = container_repository_factory(remote=remote2.pulp_href)
+    container_sync(repo1)
+    container_sync(repo2)
+    container_distribution_factory(
+        base_path="pulptest/oci-net.fishsoup.busyboxplatform", repository=repo1.pulp_href
+    )
+    container_distribution_factory(
+        base_path="pulptest/oci-net.fishsoup.hello", repository=repo2.pulp_href
+    )
+    namespace = container_namespace_api.list(name="pulptest").results[0]
+    add_to_cleanup(container_namespace_api, namespace.pulp_href)
+
+    # Assert the repos were set up correctly
+    tag = container_tag_api.list(repository_version=f"{repo2.versions_href}1/").results[0]
+    manifest = container_manifest_api.read(tag.tagged_manifest)
+    assert manifest.is_flatpak
+    assert not manifest.is_bootable
+
+    # reclaim disk space to turn the manifests + config-blogs into on-demand
+    reclaim_response = pulpcore_bindings.RepositoriesReclaimSpaceApi.reclaim(
+        {"repo_hrefs": [repo1.pulp_href, repo2.pulp_href]}
+    )
+    monitor_task(reclaim_response.task)
+
+    run_flatpak_commands(pulp_settings)

--- a/pulp_container/tests/functional/conftest.py
+++ b/pulp_container/tests/functional/conftest.py
@@ -435,6 +435,17 @@ def container_sync(container_repository_api, monitor_task):
 
 
 @pytest.fixture
+def container_distribution_factory(container_distribution_api, gen_object_with_cleanup):
+    def _container_distribution_factory(**kwargs):
+        distro = {"name": str(uuid4()), "base_path": str(uuid4())}
+        if kwargs:
+            distro.update(kwargs)
+        return gen_object_with_cleanup(container_distribution_api, distro)
+
+    return _container_distribution_factory
+
+
+@pytest.fixture
 def pull_through_distribution(
     gen_object_with_cleanup,
     container_pull_through_remote_api,


### PR DESCRIPTION
After looking through the history and current state of the Manifest model I came up with this solution to try to get the metadata off the model if it is there and then fallback to the config blob. If the config blob is not there during a fallback then the image will be skipped from the returned results of the index call. This bugfix can only really be back ported to 0.22 since it relies on the new manifest fields. Flatpak index was added in 0.16, so a different solution would be needed to be backported for these inbetween releases. Thoughts on whether I should create these other backports?

fixes: #1887