### PR TITLE
Fixed a bug on distribution create

### DIFF
--- a/CHANGES/+distribution_create.bugfix
+++ b/CHANGES/+distribution_create.bugfix
@@ -1,0 +1,1 @@
+Fixed a bug on distribution create that failed to serialize the full registry path in the task context.

--- a/pulp_container/app/serializers.py
+++ b/pulp_container/app/serializers.py
@@ -228,8 +228,11 @@ class RegistryPathField(serializers.CharField):
         """
         Converts a base_path into a registry path.
         """
-        request = self.context["request"]
-        return f"{request.get_host()}/{get_full_path(value)}"
+        request = self.context.get("request")
+        if request is not None:
+            return f"{request.get_host()}/{get_full_path(value)}"
+        else:
+            return get_full_path(value)
 
 
 class ContainerNamespaceSerializer(ModelSerializer, GetOrCreateSerializerMixin):


### PR DESCRIPTION
Due to a recent pulpcore change, the distribution serializer must be able to serialize in the task context where the request is set to none.