### PR TITLE
Fix #2199 blob chunk upload should return 202 not 204

### DIFF
--- a/CHANGES/2199.bugfix
+++ b/CHANGES/2199.bugfix
@@ -1,0 +1,2 @@
+Fixed the status code on successful ``PATCH`` on blob partial updates to be ``202``
+as requested by the OCI spec.

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -961,7 +961,7 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
             upload.size += length
             upload.save()
 
-        return UploadResponse(upload=upload, path=path, request=request, status=204)
+        return UploadResponse(upload=upload, path=path, request=request)
 
     def put(self, request, path, pk=None):
         """


### PR DESCRIPTION
status=202 is requested in the OCI spec.
podman doesn't care but regctl fails when receiving 204.

fixes #2199 
