### PR TITLE
Fix #2200 OCI_INDEX_SCHEMA shouldn't require the platform property

### DIFF
--- a/CHANGES/2200.bugfix
+++ b/CHANGES/2200.bugfix
@@ -1,0 +1,1 @@
+Made ``plaform`` optional for ``manifests`` in the JSON schema for ``vnd.oci.image.index.v1+json``.

--- a/pulp_container/app/json_schemas.py
+++ b/pulp_container/app/json_schemas.py
@@ -70,7 +70,6 @@ OCI_INDEX_SCHEMA = {
                         "required": ["architecture", "os"],
                     },
                 },
-                additional_required=["platform"],
             ),
         },
         "subject": get_descriptor_schema(),


### PR DESCRIPTION
The OCI spec marks the plaform field of vnd.oci.image.index.v1+json manifests optional.
The rest of the code handles the absence of the platform field fine.

fixes #2200