### PR TITLE
Fix monolithic push memory issues

### DIFF
--- a/CHANGES/+mono-push.bugfix
+++ b/CHANGES/+mono-push.bugfix
@@ -1,0 +1,1 @@
+Fixed memory usage when pushing large images with monolithic upload.


### PR DESCRIPTION
According to the spec there are two ways to perform monolithic blob pushes:
1. On the initial POST request with the digest query parameter
2. Empty (normal) body POST, then all in the PUT

There's an unofficial third way that podman can apparently do according to our comments which is: 
1. Normal empty POST
2. Entire chunk in one PATCH with no Range header
3. Empty PUT

The code should now call our special large chunk handler for all three cases, we were forgetting case number 2. Note that depending on the client they could still cause the server to go OOM if they send ridiculously large chunks in the normal chunked upload path since we read the entire chunk into memory before saving it. There is nothing we can do here as part of the code lives in pulpcore, but honestly what is that client thinking sending such large chunks!

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
