### PR TITLE
Migration to make two sequences BIGINT.

### DIFF
--- a/CHANGES/2080.bugfix
+++ b/CHANGES/2080.bugfix
@@ -1,0 +1,3 @@
+Altered several id-fields and their related sequences.
+
+INTEGER AutoField sequences can "run out" on large/old instances, update to BIGINT.

--- a/pulp_container/app/__init__.py
+++ b/pulp_container/app/__init__.py
@@ -1,4 +1,21 @@
 from pulpcore.plugin import PulpPluginAppConfig
+from django.db import connection
+from django.db.models.signals import post_migrate
+
+update_sequences_to_bigint = """
+ALTER TABLE container_blobmanifest ALTER COLUMN id TYPE bigint;
+ALTER TABLE container_manifestlistmanifest ALTER COLUMN id TYPE bigint;
+ALTER TABLE container_containerpushrepository_pending_blobs ALTER COLUMN id TYPE bigint;
+ALTER TABLE container_containerpushrepository_pending_manifests ALTER COLUMN id TYPE bigint;
+ALTER TABLE container_containerrepository_pending_manifests ALTER COLUMN id TYPE bigint;
+ALTER TABLE container_containerrepository_pending_blobs ALTER COLUMN id TYPE bigint;
+ALTER SEQUENCE container_blobmanifest_id_seq AS BIGINT;
+ALTER SEQUENCE container_manifestlistmanifest_id_seq AS BIGINT;
+ALTER SEQUENCE container_containerpushrepository_pending_blobs_id_seq AS BIGINT;
+ALTER SEQUENCE container_containerpushrepository_pending_manifests_id_seq AS BIGINT;
+ALTER SEQUENCE container_containerrepository_pending_blobs_id_seq AS BIGINT;
+ALTER SEQUENCE container_containerrepository_pending_manifests_id_seq AS BIGINT;
+"""
 
 
 class PulpContainerPluginAppConfig(PulpPluginAppConfig):
@@ -10,6 +27,14 @@ class PulpContainerPluginAppConfig(PulpPluginAppConfig):
     python_package_name = "pulp-container"
     domain_compatible = True
 
+    @staticmethod
+    def update_sequences(sender, **kwargs):
+        """Update database sequences to bigint type after migrations."""
+        with connection.cursor() as cursor:
+            cursor.execute(update_sequences_to_bigint)
+
     def ready(self):
         super().ready()
         from . import checks
+
+        post_migrate.connect(PulpContainerPluginAppConfig.update_sequences, sender=self)


### PR DESCRIPTION
This addresses the failure noted in https://issues.redhat.com/browse/PULP-890 .
