### PR TITLE
[PR #2270/76e495ca backport][2.27] Update pyjwt[crypto] requirement from <2.12,>=2.4 to >=2.4,<2.13

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.11"
 dependencies = [
   "jsonschema>=4.4,<4.26",
   "pulpcore>=3.73.2,<3.115",
-  "pyjwt[crypto]>=2.4,<2.11",
+  "pyjwt[crypto]>=2.4,<2.13",
   "pysequoia==0.1.32",
 ]
 


### PR DESCRIPTION
Manual backport of https://github.com/pulp/pulp_container/pull/2270 (patchback cherry-pick conflict: keep branch-specific pins, set `pyjwt[crypto]` to `>=2.4,<2.13`).

Made with [Cursor](https://cursor.com)