### PR TITLE
[PR #2270/76e495ca backport][2.19] Update pyjwt[crypto] requirement from <2.9,>=2.4 to >=2.4,<2.13

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 jsonschema>=4.4,<4.22
 pulpcore>=3.49.0,<3.55
-pyjwt[crypto]>=2.4,<2.9
+pyjwt[crypto]>=2.4,<2.13
 pysequoia==0.1.32


### PR DESCRIPTION
Manual backport of https://github.com/pulp/pulp_container/pull/2270. The 2.19 line does not use the same `pyproject.toml` `[project].dependencies` layout as main; dependencies are in `requirements.txt`. Cherry-pick could not apply cleanly, so this updates `pyjwt[crypto]` there to `>=2.4,<2.13` to match the intent of the original change.

Made with [Cursor](https://cursor.com)