### PR TITLE
Fix misuse of gpg_verify

### DIFF
--- a/functest_requirements.txt
+++ b/functest_requirements.txt
@@ -1,5 +1,6 @@
 pytest<10
 python-gnupg
+pysequoia
 pytest-xdist
 pytest-timeout
 pytest-custom_exit_code

--- a/pulp_container/app/models.py
+++ b/pulp_container/app/models.py
@@ -696,7 +696,7 @@ class ManifestSigningService(SigningService):
                 manifest_file.name, env_vars={"REFERENCE": "test", "SIG_PATH": sig_path}
             )
 
-            gpg_verify(self.public_key, signed["signature_path"])
+            gpg_verify(self.public_key, signed["signature_path"], detached_data=manifest_file.name)
 
 
 class ContainerRepository(

--- a/pulp_container/tests/functional/api/test_push_signatures.py
+++ b/pulp_container/tests/functional/api/test_push_signatures.py
@@ -1,8 +1,12 @@
 """Tests that verify that an image signature can be pushed to Pulp."""
 
 import base64
+import io
 import json
+
 import pytest
+
+from pulpcore.plugin.util import gpg_verify
 
 from pulp_container.tests.functional.constants import REGISTRY_V2_REPO_PULP
 from pulp_container.constants import SIGNATURE_TYPE
@@ -49,6 +53,7 @@ def test_assert_signed_image(
 ):
     """Test whether an admin user can fetch a signature from the Pulp Registry."""
     gpg, fingerprint, keyid = signing_gpg_metadata
+    public_key = gpg.export_keys(keyid)
 
     repository = container_push_repository_api.read(distribution.repository)
     manifest = container_manifest_api.list(
@@ -73,12 +78,12 @@ def test_assert_signed_image(
     timestamps = []
     for s in signatures:
         raw_s = base64.b64decode(s["content"])
-        decrypted = gpg.decrypt(raw_s)
+        verified = gpg_verify(public_key, io.BytesIO(raw_s))
 
-        assert decrypted.key_id == keyid
-        assert decrypted.status == "signature valid"
+        assert verified.valid
+        assert verified.pubkey_fingerprint.upper() == fingerprint.upper()
 
-        json_s = json.loads(decrypted.data)
+        json_s = json.loads(verified.data)
 
         image_path = json_s["critical"]["identity"]["docker-reference"]
         assert image_path == f"{local_registry.name}/{full_path(distribution)}:manifest_a"


### PR DESCRIPTION
It was trying to verify a detached signature without providing the detached data. PySequoia is stricter about this than gpg.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
