### PR TITLE
[2.24] Require a newer version of pysequoia to fix signature validation

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "jsonschema>=4.4,<4.24",
   "pulpcore>=3.73.0,<3.85",
   "pyjwt[crypto]>=2.4,<2.11",
-  "pysequoia==0.1.32"
+  "pysequoia>=0.1.33,<0.2.0"
 ]
 
 [project.urls]


### PR DESCRIPTION
skopeo standalone-verify creates slightly atypical (but legal) PGP signatures which pysequoia <= 0.1.32 was rejecting (via gpg_verify() from pulpcore).

We need to declare compatibility with the new version

(cherry picked from commit 4b009449b14db0aa38173c20839b077a5e29d6a9)

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
