### PR TITLE
Adopt the "ResourceBudget" limiter from Pulpcore

### DIFF
--- a/CHANGES/+resource-budget.bugfix
+++ b/CHANGES/+resource-budget.bugfix
@@ -1,0 +1,1 @@
+Take advantage of pulpcore's `ResourceBudget` feature which enables the sync pipeline to keep disk usage down without an excessive performance hit.

--- a/pulp_container/app/tasks/synchronize.py
+++ b/pulp_container/app/tasks/synchronize.py
@@ -2,6 +2,7 @@ import logging
 
 from pulpcore.plugin.stages import (
     ArtifactDownloader,
+    ArtifactResourceBudget,
     ArtifactSaver,
     DeclarativeVersion,
     QueryExistingArtifacts,
@@ -68,11 +69,13 @@ class ContainerDeclarativeVersion(DeclarativeVersion):
             list: List of :class:`~pulpcore.plugin.stages.Stage` instances
 
         """
+        resource_budget = ArtifactResourceBudget.from_settings()
+
         pipeline = [
             self.first_stage,
             QueryExistingArtifacts(),
-            ArtifactDownloader(),
-            ArtifactSaver(),
+            ArtifactDownloader(resource_budget=resource_budget),
+            ArtifactSaver(resource_budget=resource_budget),
             QueryExistingContents(),
             ContainerContentSaver(),
             RemoteArtifactSaver(),

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers=[
 requires-python = ">=3.11"
 dependencies = [
   "jsonschema>=4.4,<4.27",
-  "pulpcore>=3.73.2,<3.115",
+  "pulpcore>=3.111.0,<3.115",
   "pyjwt[crypto]>=2.4,<2.13",
   "pysequoia>=0.1.33,<0.2.0"
 ]


### PR DESCRIPTION
Puts a limiter on the amount of data that can be held locally between artifact download and saving (to content storage).

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
