### PR TITLE
Include DEFAULT_AUTHENTICATION_CLASSES when token auth is disabled

### DIFF
--- a/CHANGES/2362.feature
+++ b/CHANGES/2362.feature
@@ -1,0 +1,3 @@
+When token auth is disabled, container registry API views now include
+DEFAULT_AUTHENTICATION_CLASSES alongside RegistryAuthentication, allowing
+deployments to use custom authentication backends.

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -230,9 +230,14 @@ class ContainerRegistryApiMixin:
     def authentication_classes(self):
         """
         List of authentication classes to check for this view.
+
+        When token auth is disabled, includes both RegistryAuthentication (Basic auth)
+        and any authentication classes configured in DEFAULT_AUTHENTICATION_CLASSES.
+        This allows deployments to use custom authentication backends (e.g. remote
+        header-based auth) alongside standard Basic auth for container registry operations.
         """
         if settings.get("TOKEN_AUTH_DISABLED", False):
-            return [RegistryAuthentication]
+            return [RegistryAuthentication, *api_settings.DEFAULT_AUTHENTICATION_CLASSES]
         return [TokenAuthentication]
 
     @property


### PR DESCRIPTION
## Summary
- When `TOKEN_AUTH_DISABLED=True`, `ContainerRegistryApiMixin.authentication_classes` now includes `DEFAULT_AUTHENTICATION_CLASSES` alongside `RegistryAuthentication`
- This allows deployments to use custom authentication backends (e.g. remote header-based auth) for container registry operations without maintaining a downstream patch
- `RegistryAuthentication` remains first for backwards compatibility

Fixes #2362

## Test plan
- [x] Existing tests pass (no behavior change for deployments not using custom auth backends)
- [x] Deployments with custom `DEFAULT_AUTHENTICATION_CLASSES` can authenticate to registry API when `TOKEN_AUTH_DISABLED=True`