### PR TITLE
Add DELETE support for cancelling blob uploads

### DIFF
--- a/CHANGES/+cancel-blob-upload.feature
+++ b/CHANGES/+cancel-blob-upload.feature
@@ -1,0 +1,1 @@
+Added support for cancelling blob uploads via `DELETE /v2/<name>/blobs/uploads/<uuid>`.

--- a/pulp_container/app/exceptions.py
+++ b/pulp_container/app/exceptions.py
@@ -90,6 +90,24 @@ class BlobInvalid(ParseError):
         )
 
 
+class BlobUploadUnknown(NotFound):
+    """Exception to render a 404 with the code 'BLOB_UPLOAD_UNKNOWN'"""
+
+    def __init__(self, uuid):
+        """Initialize the exception with the upload uuid."""
+        super().__init__(
+            detail={
+                "errors": [
+                    {
+                        "code": "BLOB_UPLOAD_UNKNOWN",
+                        "message": "blob upload unknown to registry",
+                        "detail": {"uuid": uuid},
+                    }
+                ]
+            }
+        )
+
+
 class ManifestNotFound(NotFound):
     """Exception to render a 404 with the code 'MANIFEST_UNKNOWN'"""
 

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -66,6 +66,7 @@ from pulp_container.app.exceptions import (
     BadGateway,
     BlobInvalid,
     BlobNotFound,
+    BlobUploadUnknown,
     GatewayTimeout,
     InvalidRequest,
     ManifestInvalid,
@@ -1041,6 +1042,18 @@ class BlobUploads(ContainerRegistryApiMixin, ViewSet):
     def head(self, request, path, pk=None):
         """Respond to HEAD requests about blob uploads."""
         return self.get(request, path, pk=pk)
+
+    def destroy(self, request, path, pk=None):
+        """
+        Cancel an outstanding blob upload.
+        """
+        _, repository = self.get_dr_push(request, path)
+        try:
+            upload = models.Upload.objects.get(repository=repository, pk=pk)
+        except models.Upload.DoesNotExist:
+            raise BlobUploadUnknown(uuid=pk)
+        upload.delete()
+        return Response(status=204)
 
     def put(self, request, path, pk=None):
         """

--- a/pulp_container/tests/functional/api/test_cancel_blob_upload.py
+++ b/pulp_container/tests/functional/api/test_cancel_blob_upload.py
@@ -1,0 +1,72 @@
+"""Tests for cancelling blob uploads via the Docker v2 API."""
+
+import uuid
+
+import pytest
+
+from pulp_container.app import models
+
+
+class TestCancelBlobUpload:
+    """Tests for DELETE /v2/<name>/blobs/uploads/<uuid>."""
+
+    repo_name = "cancel/upload"
+
+    @pytest.fixture(scope="class")
+    def setup(
+        self,
+        add_to_cleanup,
+        container_bindings,
+        local_registry,
+        full_path,
+    ):
+        """Create a push repository for all cancel blob upload tests."""
+        upload_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/"
+        response, _ = local_registry.get_response("POST", upload_path)
+        assert response.status_code == 202
+
+        distribution = container_bindings.DistributionsContainerApi.list(name=self.repo_name).results[0]
+        add_to_cleanup(container_bindings.PulpContainerNamespacesApi, distribution.namespace)
+
+        upload_uuid = response.headers["Docker-Upload-UUID"]
+        delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
+        local_registry.get_response("DELETE", delete_path)
+
+    def _start_upload(self, local_registry, full_path):
+        upload_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/"
+        response, _ = local_registry.get_response("POST", upload_path)
+        assert response.status_code == 202
+        return response.headers["Docker-Upload-UUID"]
+
+    def test_01_cancel_unknown_blob_upload(self, setup, local_registry, full_path):
+        """Cancelling a blob upload that does not exist returns 404."""
+        upload_uuid = uuid.uuid4()
+        delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
+        response, _ = local_registry.get_response("DELETE", delete_path)
+        assert response.status_code == 404
+        assert response.json()["errors"][0]["code"] == "BLOB_UPLOAD_UNKNOWN"
+
+    def test_02_cancel_blob_upload_without_permission(
+        self, setup, gen_user, local_registry, full_path, pulp_settings
+    ):
+        """Cancel requires push permissions on the namespace."""
+        if pulp_settings.TOKEN_AUTH_DISABLED:
+            pytest.skip("RBAC cannot be tested when token authentication is disabled")
+
+        upload_uuid = self._start_upload(local_registry, full_path)
+        delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
+        user_helpless = gen_user()
+        with user_helpless:
+            response, _ = local_registry.get_response("DELETE", delete_path)
+        assert response.status_code == 401
+
+    def test_03_cancel_blob_upload(self, setup, local_registry, full_path):
+        """Cancel an outstanding blob upload via DELETE /v2/<name>/blobs/uploads/<uuid>."""
+        upload_uuid = self._start_upload(local_registry, full_path)
+        assert models.Upload.objects.filter(pk=upload_uuid).exists()
+
+        delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
+        response, _ = local_registry.get_response("DELETE", delete_path)
+        assert response.status_code == 204
+        assert response.content == b""
+        assert not models.Upload.objects.filter(pk=upload_uuid).exists()

--- a/pulp_container/tests/functional/api/test_cancel_blob_upload.py
+++ b/pulp_container/tests/functional/api/test_cancel_blob_upload.py
@@ -10,7 +10,7 @@ class TestCancelBlobUpload:
 
     repo_name = "cancel/upload"
 
-    @pytest.fixture(scope="class")
+    @pytest.fixture
     def setup(
         self,
         add_to_cleanup,
@@ -18,7 +18,7 @@ class TestCancelBlobUpload:
         local_registry,
         full_path,
     ):
-        """Create a push repository and blob upload for all cancel blob upload tests."""
+        """Create a push repository and blob upload for cancel blob upload tests."""
         upload_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/"
         response, _ = local_registry.get_response("POST", upload_path)
         assert response.status_code == 202

--- a/pulp_container/tests/functional/api/test_cancel_blob_upload.py
+++ b/pulp_container/tests/functional/api/test_cancel_blob_upload.py
@@ -23,7 +23,9 @@ class TestCancelBlobUpload:
         response, _ = local_registry.get_response("POST", upload_path)
         assert response.status_code == 202
 
-        distribution = container_bindings.DistributionsContainerApi.list(name=self.repo_name).results[0]
+        distribution = container_bindings.DistributionsContainerApi.list(
+            name=self.repo_name
+        ).results[0]
         add_to_cleanup(container_bindings.PulpContainerNamespacesApi, distribution.namespace)
 
         upload_uuid = response.headers["Docker-Upload-UUID"]
@@ -37,7 +39,9 @@ class TestCancelBlobUpload:
         assert response.status_code == 404
         assert response.json()["errors"][0]["code"] == "BLOB_UPLOAD_UNKNOWN"
 
-    def test_02_cancel_blob_upload_without_permission(self, setup, gen_user, local_registry, full_path):
+    def test_02_cancel_blob_upload_without_permission(
+        self, setup, gen_user, local_registry, full_path
+    ):
         """Cancel requires push permissions on the namespace."""
         upload_uuid = setup
         delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"

--- a/pulp_container/tests/functional/api/test_cancel_blob_upload.py
+++ b/pulp_container/tests/functional/api/test_cancel_blob_upload.py
@@ -4,8 +4,6 @@ import uuid
 
 import pytest
 
-from pulp_container.app import models
-
 
 class TestCancelBlobUpload:
     """Tests for DELETE /v2/<name>/blobs/uploads/<uuid>."""
@@ -51,10 +49,15 @@ class TestCancelBlobUpload:
     def test_03_cancel_blob_upload(self, setup, local_registry, full_path):
         """Cancel an outstanding blob upload via DELETE /v2/<name>/blobs/uploads/<uuid>."""
         upload_uuid = setup
-        assert models.Upload.objects.filter(pk=upload_uuid).exists()
+        upload_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
 
-        delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
-        response, _ = local_registry.get_response("DELETE", delete_path)
+        response, _ = local_registry.get_response("GET", upload_path)
+        assert response.status_code == 204
+        assert response.headers["Docker-Upload-UUID"] == upload_uuid
+
+        response, _ = local_registry.get_response("DELETE", upload_path)
         assert response.status_code == 204
         assert response.content == b""
-        assert not models.Upload.objects.filter(pk=upload_uuid).exists()
+
+        response, _ = local_registry.get_response("GET", upload_path)
+        assert response.status_code == 404

--- a/pulp_container/tests/functional/api/test_cancel_blob_upload.py
+++ b/pulp_container/tests/functional/api/test_cancel_blob_upload.py
@@ -20,7 +20,7 @@ class TestCancelBlobUpload:
         local_registry,
         full_path,
     ):
-        """Create a push repository for all cancel blob upload tests."""
+        """Create a push repository and blob upload for all cancel blob upload tests."""
         upload_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/"
         response, _ = local_registry.get_response("POST", upload_path)
         assert response.status_code == 202
@@ -29,14 +29,7 @@ class TestCancelBlobUpload:
         add_to_cleanup(container_bindings.PulpContainerNamespacesApi, distribution.namespace)
 
         upload_uuid = response.headers["Docker-Upload-UUID"]
-        delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
-        local_registry.get_response("DELETE", delete_path)
-
-    def _start_upload(self, local_registry, full_path):
-        upload_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/"
-        response, _ = local_registry.get_response("POST", upload_path)
-        assert response.status_code == 202
-        return response.headers["Docker-Upload-UUID"]
+        return upload_uuid
 
     def test_01_cancel_unknown_blob_upload(self, setup, local_registry, full_path):
         """Cancelling a blob upload that does not exist returns 404."""
@@ -46,23 +39,18 @@ class TestCancelBlobUpload:
         assert response.status_code == 404
         assert response.json()["errors"][0]["code"] == "BLOB_UPLOAD_UNKNOWN"
 
-    def test_02_cancel_blob_upload_without_permission(
-        self, setup, gen_user, local_registry, full_path, pulp_settings
-    ):
+    def test_02_cancel_blob_upload_without_permission(self, setup, gen_user, local_registry, full_path):
         """Cancel requires push permissions on the namespace."""
-        if pulp_settings.TOKEN_AUTH_DISABLED:
-            pytest.skip("RBAC cannot be tested when token authentication is disabled")
-
-        upload_uuid = self._start_upload(local_registry, full_path)
+        upload_uuid = setup
         delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
         user_helpless = gen_user()
         with user_helpless:
             response, _ = local_registry.get_response("DELETE", delete_path)
-        assert response.status_code == 401
+        assert response.status_code in (401, 403)
 
     def test_03_cancel_blob_upload(self, setup, local_registry, full_path):
         """Cancel an outstanding blob upload via DELETE /v2/<name>/blobs/uploads/<uuid>."""
-        upload_uuid = self._start_upload(local_registry, full_path)
+        upload_uuid = setup
         assert models.Upload.objects.filter(pk=upload_uuid).exists()
 
         delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"

--- a/pulp_container/tests/functional/api/test_cancel_blob_upload.py
+++ b/pulp_container/tests/functional/api/test_cancel_blob_upload.py
@@ -5,31 +5,35 @@ import uuid
 import pytest
 
 
+def _start_blob_upload(local_registry, full_path, repo_name):
+    upload_path = f"/v2/{full_path(repo_name)}/blobs/uploads/"
+    response, _ = local_registry.get_response("POST", upload_path)
+    assert response.status_code == 202
+    return response.headers["Docker-Upload-UUID"]
+
+
 class TestCancelBlobUpload:
     """Tests for DELETE /v2/<name>/blobs/uploads/<uuid>."""
 
     repo_name = "cancel/upload"
 
-    @pytest.fixture
+    @pytest.fixture(scope="class")
     def setup(
         self,
         add_to_cleanup,
         container_bindings,
-        local_registry,
-        full_path,
+        container_repository_factory,
+        container_distribution_factory,
     ):
-        """Create a push repository and blob upload for cancel blob upload tests."""
-        upload_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/"
-        response, _ = local_registry.get_response("POST", upload_path)
-        assert response.status_code == 202
-
-        distribution = container_bindings.DistributionsContainerApi.list(
-            name=self.repo_name
-        ).results[0]
-        add_to_cleanup(container_bindings.PulpContainerNamespacesApi, distribution.namespace)
-
-        upload_uuid = response.headers["Docker-Upload-UUID"]
-        return upload_uuid
+        """Create a push repository and distribution for all cancel blob upload tests."""
+        repository = container_repository_factory()
+        distribution = container_distribution_factory(
+            name=self.repo_name,
+            base_path=self.repo_name,
+            repository=repository.pulp_href,
+        )
+        namespace = container_bindings.PulpContainerNamespacesApi.read(distribution.namespace)
+        add_to_cleanup(container_bindings.PulpContainerNamespacesApi, namespace.pulp_href)
 
     def test_01_cancel_unknown_blob_upload(self, setup, local_registry, full_path):
         """Cancelling a blob upload that does not exist returns 404."""
@@ -43,7 +47,7 @@ class TestCancelBlobUpload:
         self, setup, gen_user, local_registry, full_path
     ):
         """Cancel requires push permissions on the namespace."""
-        upload_uuid = setup
+        upload_uuid = _start_blob_upload(local_registry, full_path, self.repo_name)
         delete_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
         user_helpless = gen_user()
         with user_helpless:
@@ -52,7 +56,7 @@ class TestCancelBlobUpload:
 
     def test_03_cancel_blob_upload(self, setup, local_registry, full_path):
         """Cancel an outstanding blob upload via DELETE /v2/<name>/blobs/uploads/<uuid>."""
-        upload_uuid = setup
+        upload_uuid = _start_blob_upload(local_registry, full_path, self.repo_name)
         upload_path = f"/v2/{full_path(self.repo_name)}/blobs/uploads/{upload_uuid}"
 
         response, _ = local_registry.get_response("GET", upload_path)


### PR DESCRIPTION
## Summary
- Implement `DELETE /v2/<name>/blobs/uploads/<uuid>` to cancel outstanding blob uploads
- Return `204 No Content` on success and `404 BLOB_UPLOAD_UNKNOWN` when the upload does not exist
- Add functional tests for cancel, unknown upload, and RBAC

Closes #482

## Test plan
- [ ] Run `pytest pulp_container/tests/functional/api/test_cancel_blob_upload.py`
- [ ] Start a blob upload, cancel it with DELETE, and confirm the upload record is removed
- [ ] DELETE a non-existent upload UUID and confirm `BLOB_UPLOAD_UNKNOWN`
- [ ] Verify an unauthenticated/unauthorized user receives `401`


Made with [Cursor](https://cursor.com)