### PR TITLE
[PR #2367/aeecfe46 backport][2.26] Update pyjwt[crypto] requirement from <2.13,>=2.4 to >=2.4,<2.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ requires-python = ">=3.11"
 dependencies = [
   "jsonschema>=4.4,<4.25",
   "pulpcore>=3.73.2,<3.100",
-  "pyjwt[crypto]>=2.4,<2.13",
+  "pyjwt[crypto]>=2.4,<2.14",
   "pysequoia>=0.1.33,<0.2.0"
 ]
 


### PR DESCRIPTION
Manual backport of https://github.com/pulp/pulp_container/pull/2367 (patchback cherry-pick failed because dependency pins live in `requirements.txt` on older branches or differ from `main`).

Permits pyjwt 2.13.0, which includes security fixes.

Made with [Cursor](https://cursor.com)