### PR TITLE
Switch to getattr(settings, ...)

### DIFF
--- a/pulp_container/app/authorization.py
+++ b/pulp_container/app/authorization.py
@@ -24,7 +24,7 @@ from pulp_container.app.models import (
     ContainerPullThroughDistribution,
 )
 
-TOKEN_EXPIRATION_TIME = settings.get("TOKEN_EXPIRATION_TIME", 300)
+TOKEN_EXPIRATION_TIME = getattr(settings, "TOKEN_EXPIRATION_TIME", 300)
 
 FakeView = namedtuple("FakeView", "action, get_object, get_serializer")
 

--- a/pulp_container/app/registry_api.py
+++ b/pulp_container/app/registry_api.py
@@ -230,7 +230,7 @@ class ContainerRegistryApiMixin:
         """
         List of authentication classes to check for this view.
         """
-        if settings.get("TOKEN_AUTH_DISABLED", False):
+        if getattr(settings, "TOKEN_AUTH_DISABLED", False):
             return [RegistryAuthentication]
         return [TokenAuthentication]
 
@@ -239,7 +239,7 @@ class ContainerRegistryApiMixin:
         """
         List of permission classes to check for this view.
         """
-        if settings.get("TOKEN_AUTH_DISABLED", False):
+        if getattr(settings, "TOKEN_AUTH_DISABLED", False):
             return [RegistryPermission]
         return [TokenPermission]
 
@@ -468,7 +468,7 @@ class VersionView(ContainerRegistryApiMixin, APIView):
         """
         List of permission classes to check for this view.
         """
-        if settings.get("TOKEN_AUTH_DISABLED", False):
+        if getattr(settings, "TOKEN_AUTH_DISABLED", False):
             return [IsAuthenticated]
         return [TokenPermission]
 
@@ -560,7 +560,7 @@ class CatalogView(ContainerRegistryApiMixin, ListAPIView):
         distribution_permission = "container.pull_containerdistribution"
         namespace_permission = "container.namespace_pull_containerdistribution"
 
-        if settings.get("TOKEN_AUTH_DISABLED", False):
+        if getattr(settings, "TOKEN_AUTH_DISABLED", False):
             return queryset
 
         public_repositories = queryset.filter(private=False)

--- a/pulp_container/tests/functional/api/test_content_cache.py
+++ b/pulp_container/tests/functional/api/test_content_cache.py
@@ -76,7 +76,7 @@ def test_content_cache(
     monitor_task,
 ):
     """A test case that verifies the functionality of the Redis caching machinery."""
-    if not pulp_settings.get("CACHE_ENABLED"):
+    if not getattr(pulp_settings, "CACHE_ENABLED", False):
         pytest.skip("The caching machinery was not enabled")
 
     repo = container_repository_factory()


### PR DESCRIPTION
I'm not sure if this is the only plugin preventing the 3.105 image from being built (https://github.com/pulp/pulp-oci-images/actions/runs/30414513424/job/90457993386#step:4:591) and the correct solution is to get a new release of dynaconf with the proper fix, but maybe this can get the CI green again.

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
