### PR TITLE
fix: switch to instance attributes

### DIFF
--- a/CHANGES/+multiple-registries-auth-state.bugfix
+++ b/CHANGES/+multiple-registries-auth-state.bugfix
@@ -1,0 +1,1 @@
+Fixed authentication state (bearer token and basic auth) leaking between remotes by storing it per downloader instance instead of on the downloader class.

--- a/pulp_container/app/downloaders.py
+++ b/pulp_container/app/downloaders.py
@@ -25,14 +25,13 @@ class RegistryAuthHttpDownloader(HttpDownloader):
     Additionally, use custom headers from DeclarativeArtifact.extra_data['headers']
     """
 
-    registry_auth = {"bearer": None, "basic": None}
-    token_lock = asyncio.Lock()
-
     def __init__(self, *args, **kwargs):
         """
         Initialize the downloader.
         """
         self.remote = kwargs.pop("remote")
+        self.registry_auth = {"bearer": None, "basic": None}
+        self.token_lock = asyncio.Lock()
 
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Store registry_auth and token_lock per downloader instance instead of as class attributes so that auth state (bearer token, basic auth) does not leak between different remotes/registries.

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [x] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [x] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [x] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [x] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
