### PR TITLE
[2.27] Bump pulpcore lower bound to 3.73.42

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ classifiers=[
 requires-python = ">=3.11"
 dependencies = [
   "jsonschema>=4.4,<4.26",
-  "pulpcore>=3.73.2,<3.115",
+  "pulpcore>=3.73.42,<3.115",
   "pyjwt[crypto]>=2.4,<2.14",
   "pysequoia>=0.1.33,<0.2.0"
 ]


### PR DESCRIPTION
Backports should fix the failing lowerbound runners in #2445 and #2447

<!---
Thank you for submitting a PR to the Pulp Project!

If this is your first time contributing, please read the Pull Request Walkthrough documentation
(https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/).
-->

### 📜 Checklist

- [ ] Commits are cleanly separated with meaningful messages (simple features and bug fixes should be [squashed](https://pulpproject.org/pulpcore/docs/dev/guides/git/#rebasing-and-squashing) to one commit)
- [ ] A [changelog entry](https://pulpproject.org/pulpcore/docs/dev/guides/git/#changelog-update) or entries has been added for any significant changes
- [ ] Follows the [Pulp policy on AI Usage](https://pulpproject.org/help/more/governance/ai_policy/)
- [ ] (For new features) - User documentation and test coverage has been added

See: [Pull Request Walkthrough](https://pulpproject.org/pulpcore/docs/dev/guides/pull-request-walkthrough/)
